### PR TITLE
Do not use insecure mode in tests, tests for server-side subs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
         uses: crazy-max/ghaction-setup-docker@v3
 
       - name: Start Centrifugo
-        run: docker run -d -p 8000:8000 -e CENTRIFUGO_PRESENCE=true -e CENTRIFUGO_JOIN_LEAVE=true -e CENTRIFUGO_FORCE_PUSH_JOIN_LEAVE=true -e CENTRIFUGO_HISTORY_TTL=300s -e CENTRIFUGO_HISTORY_SIZE=100 -e CENTRIFUGO_FORCE_RECOVERY=true centrifugo/centrifugo:v5 centrifugo --client_insecure
+        run: docker run -d -p 8000:8000 -e CENTRIFUGO_TOKEN_HMAC_SECRET_KEY="secret" -e CENTRIFUGO_PRESENCE=1 -e CENTRIFUGO_JOIN_LEAVE=true -e CENTRIFUGO_FORCE_PUSH_JOIN_LEAVE=true -e CENTRIFUGO_HISTORY_TTL=300s -e CENTRIFUGO_HISTORY_SIZE=100 -e CENTRIFUGO_FORCE_RECOVERY=true -e CENTRIFUGO_USER_SUBSCRIBE_TO_PERSONAL=true -e CENTRIFUGO_ALLOW_PUBLISH_FOR_SUBSCRIBER=true -e CENTRIFUGO_ALLOW_PRESENCE_FOR_SUBSCRIBER=true -e CENTRIFUGO_ALLOW_HISTORY_FOR_SUBSCRIBER=true centrifugo/centrifugo:v5 centrifugo
 
       - name: Install dependencies
         run: |

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: proto test lint lint-ci
+.PHONY: proto test lint lint-fix lint-ci
 
 dev:
 	pip install -e ".[dev]"
@@ -11,6 +11,9 @@ test:
 
 lint:
 	ruff .
+
+lint-fix:
+	ruff . --fix
 
 lint-ci:
 	ruff . --output-format=github

--- a/centrifuge/__init__.py
+++ b/centrifuge/__init__.py
@@ -4,7 +4,6 @@ from .client import Client, ClientState, Subscription, SubscriptionState
 from .contexts import (
     ConnectedContext,
     ConnectingContext,
-    ClientTokenContext,
     DisconnectedContext,
     ErrorContext,
     JoinContext,
@@ -19,7 +18,6 @@ from .contexts import (
     SubscribedContext,
     SubscribingContext,
     SubscriptionErrorContext,
-    SubscriptionTokenContext,
     UnsubscribedContext,
 )
 from .exceptions import (
@@ -50,7 +48,6 @@ __all__ = [
     "ClientEventHandler",
     "ClientInfo",
     "ClientState",
-    "ClientTokenContext",
     "ConnectedContext",
     "ConnectingContext",
     "DisconnectedContext",
@@ -80,7 +77,6 @@ __all__ = [
     "SubscriptionErrorContext",
     "SubscriptionEventHandler",
     "SubscriptionState",
-    "SubscriptionTokenContext",
     "SubscriptionUnsubscribedError",
     "UnauthorizedError",
     "UnsubscribedContext",

--- a/centrifuge/contexts.py
+++ b/centrifuge/contexts.py
@@ -178,15 +178,3 @@ class SubscriptionErrorContext:
 
     code: int
     error: Exception
-
-
-@dataclass
-class ClientTokenContext:
-    """ClientTokenContext is a context passed to get_token callback of connection."""
-
-
-@dataclass
-class SubscriptionTokenContext:
-    """SubscriptionTokenContext is a context passed to get_token callback of subscription."""
-
-    channel: str


### PR DESCRIPTION
Not using insecure mode on server shifts tests closer to reality.

Also removing ClientTokenContext and SubscriptionTokenContext.