### PR TITLE
Up websockets dependency, drop python 3.8

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,6 @@ jobs:
         os:
           - ubuntu-latest
         python-version:
-          - "3.8"
           - "3.9"
           - "3.10"
           - "3.11"
@@ -21,6 +20,9 @@ jobs:
         protobuf-version:
           - "4.23.4"
           - "5.29.3"
+        websockets-version:
+          - "14.2"
+          - "15.0"
 
     runs-on: ${{ matrix.os }}
 
@@ -37,12 +39,13 @@ jobs:
         uses: crazy-max/ghaction-setup-docker@v3
 
       - name: Start Centrifugo
-        run: docker run -d -p 8000:8000 -e CENTRIFUGO_TOKEN_HMAC_SECRET_KEY="secret" -e CENTRIFUGO_PRESENCE=true -e CENTRIFUGO_JOIN_LEAVE=true -e CENTRIFUGO_FORCE_PUSH_JOIN_LEAVE=true -e CENTRIFUGO_HISTORY_TTL=300s -e CENTRIFUGO_HISTORY_SIZE=100 -e CENTRIFUGO_FORCE_RECOVERY=true -e CENTRIFUGO_USER_SUBSCRIBE_TO_PERSONAL=true -e CENTRIFUGO_ALLOW_PUBLISH_FOR_SUBSCRIBER=true -e CENTRIFUGO_ALLOW_PRESENCE_FOR_SUBSCRIBER=true -e CENTRIFUGO_ALLOW_HISTORY_FOR_SUBSCRIBER=true -e CENTRIFUGO_DELTA_PUBLISH=true -e CENTRIFUGO_ALLOWED_DELTA_TYPES="fossil" centrifugo/centrifugo:v5 centrifugo
+        run: docker run -d -p 8000:8000 -e CENTRIFUGO_CLIENT_TOKEN_HMAC_SECRET_KEY="secret" -e CENTRIFUGO_CHANNEL_WITHOUT_NAMESPACE_ALLOWED_DELTA_TYPES="fossil" -e CENTRIFUGO_CHANNEL_WITHOUT_NAMESPACE_DELTA_PUBLISH="true" -e CENTRIFUGO_CHANNEL_WITHOUT_NAMESPACE_PRESENCE="true" -e CENTRIFUGO_CHANNEL_WITHOUT_NAMESPACE_JOIN_LEAVE="true" -e CENTRIFUGO_CHANNEL_WITHOUT_NAMESPACE_FORCE_PUSH_JOIN_LEAVE="true" -e CENTRIFUGO_CHANNEL_WITHOUT_NAMESPACE_HISTORY_SIZE="100" -e CENTRIFUGO_CHANNEL_WITHOUT_NAMESPACE_HISTORY_TTL="300s" -e CENTRIFUGO_CHANNEL_WITHOUT_NAMESPACE_FORCE_RECOVERY="true" -e CENTRIFUGO_CHANNEL_WITHOUT_NAMESPACE_ALLOW_PUBLISH_FOR_SUBSCRIBER="true" -e CENTRIFUGO_CHANNEL_WITHOUT_NAMESPACE_ALLOW_PRESENCE_FOR_SUBSCRIBER="true" -e CENTRIFUGO_CHANNEL_WITHOUT_NAMESPACE_ALLOW_HISTORY_FOR_SUBSCRIBER="true" -e CENTRIFUGO_CLIENT_SUBSCRIBE_TO_USER_PERSONAL_CHANNEL_ENABLED="true" -e CENTRIFUGO_LOG_LEVEL="trace" centrifugo/centrifugo:v6 centrifugo
 
       - name: Install dependencies
         run: |
           pip install --upgrade pip
           pip install "protobuf==${{ matrix.protobuf-version }}"
+          pip install "websockets==${{ matrix.websockets-version }}"
           make dev
 
       - name: Run tests

--- a/README.md
+++ b/README.md
@@ -53,20 +53,26 @@ To run [example](https://github.com/centrifugal/centrifuge-python/blob/master/ex
 
 ```json
 {
-  "token_hmac_secret_key": "secret",
-  "namespaces": [
-    {
-      "name": "example",
-      "presence": true,
-      "history_size": 300,
-      "history_ttl": "300s",
-      "join_leave": true,
-      "force_push_join_leave": true,
-      "allow_publish_for_subscriber": true,
-      "allow_presence_for_subscriber": true,
-      "allow_history_for_subscriber": true
+  "client": {
+    "token": {
+      "hmac_secret_key": "secret"
     }
-  ]
+  },
+  "channel": {
+    "namespaces": [
+      {
+        "name": "example",
+        "presence": true,
+        "history_size": 300,
+        "history_ttl": "300s",
+        "join_leave": true,
+        "force_push_join_leave": true,
+        "allow_publish_for_subscriber": true,
+        "allow_presence_for_subscriber": true,
+        "allow_history_for_subscriber": true
+      }
+    ]
+  }
 }
 ```
 
@@ -85,14 +91,22 @@ To run tests, first start Centrifugo server:
 
 ```bash
 docker pull centrifugo/centrifugo:v5
-docker run -d -p 8000:8000 -e CENTRIFUGO_LOG_LEVEL=trace \
--e CENTRIFUGO_TOKEN_HMAC_SECRET_KEY="secret" -e CENTRIFUGO_PRESENCE=true \
--e CENTRIFUGO_JOIN_LEAVE=true -e CENTRIFUGO_FORCE_PUSH_JOIN_LEAVE=true \
--e CENTRIFUGO_HISTORY_TTL=300s -e CENTRIFUGO_HISTORY_SIZE=100 \
--e CENTRIFUGO_DELTA_PUBLISH=true -e CENTRIFUGO_ALLOWED_DELTA_TYPES="fossil" \
--e CENTRIFUGO_FORCE_RECOVERY=true -e CENTRIFUGO_USER_SUBSCRIBE_TO_PERSONAL=true \
--e CENTRIFUGO_ALLOW_PUBLISH_FOR_SUBSCRIBER=true -e CENTRIFUGO_ALLOW_PRESENCE_FOR_SUBSCRIBER=true \
--e CENTRIFUGO_ALLOW_HISTORY_FOR_SUBSCRIBER=true centrifugo/centrifugo:v5 centrifugo
+docker run -d -p 8000:8000 \
+-e CENTRIFUGO_CLIENT_TOKEN_HMAC_SECRET_KEY="secret" \
+-e CENTRIFUGO_CHANNEL_WITHOUT_NAMESPACE_ALLOWED_DELTA_TYPES="fossil" \
+-e CENTRIFUGO_CHANNEL_WITHOUT_NAMESPACE_DELTA_PUBLISH="true" \
+-e CENTRIFUGO_CHANNEL_WITHOUT_NAMESPACE_PRESENCE="true" \
+-e CENTRIFUGO_CHANNEL_WITHOUT_NAMESPACE_JOIN_LEAVE="true" \
+-e CENTRIFUGO_CHANNEL_WITHOUT_NAMESPACE_FORCE_PUSH_JOIN_LEAVE="true" \
+-e CENTRIFUGO_CHANNEL_WITHOUT_NAMESPACE_HISTORY_SIZE="100" \
+-e CENTRIFUGO_CHANNEL_WITHOUT_NAMESPACE_HISTORY_TTL="300s" \
+-e CENTRIFUGO_CHANNEL_WITHOUT_NAMESPACE_FORCE_RECOVERY="true" \
+-e CENTRIFUGO_CHANNEL_WITHOUT_NAMESPACE_ALLOW_PUBLISH_FOR_SUBSCRIBER="true" \
+-e CENTRIFUGO_CHANNEL_WITHOUT_NAMESPACE_ALLOW_PRESENCE_FOR_SUBSCRIBER="true" \
+-e CENTRIFUGO_CHANNEL_WITHOUT_NAMESPACE_ALLOW_HISTORY_FOR_SUBSCRIBER="true" \
+-e CENTRIFUGO_CLIENT_SUBSCRIBE_TO_USER_PERSONAL_CHANNEL_ENABLED="true" \
+-e CENTRIFUGO_LOG_LEVEL="trace" \
+centrifugo/centrifugo:v6 centrifugo
 ```
 
 And then (from cloned repo root):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 name = "centrifuge-python"
 description = "WebSocket SDK for Centrifugo (and any Centrifuge-based server) on top of Python asyncio library"
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 license = "MIT"
 authors = [
     { name = "Alexander Emelin (Centrifugal Labs LTD)", email = "" },
@@ -28,7 +28,6 @@ classifiers = [
     "Framework :: AsyncIO",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
@@ -41,7 +40,7 @@ classifiers = [
     "Typing :: Typed",
 ]
 dependencies = [
-    "websockets>=11.0.3,<12.0.0",
+    "websockets>=14.0.0,<16.0.0",
     "protobuf>=4.23.4,<6.0.0",
 ]
 


### PR DESCRIPTION
This is a continuation of #32 

1. Up websocket dependency from `websockets>=11.0.3,<12.0.0` to `websockets>=14.0.0,<16.0.0`
2. Drop Python 3.8 support (reached EOL)
3. Update readme and CI to use Centrifugo v6