### PR TITLE
support ssl_context option

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,36 @@ When using Protobuf protocol:
 * all payloads received from the library will be `bytes` or `None` if not present.
 * don't forget that when using Protobuf protocol you can still have JSON payloads - just encode them to `bytes` before passing to the library.
 
+## Custom TLS configuration
+
+When connecting to a `wss://` endpoint the SDK uses the default TLS context of the `ssl` module – i.e. server certificates are verified against the system CA store. To customize TLS – for example to trust a custom CA – pass your own `ssl.SSLContext` as `ssl_context` option:
+
+```python
+import ssl
+
+ssl_ctx = ssl.create_default_context(cafile="/path/to/ca.pem")
+
+client = Client(
+    "wss://localhost:8000/connection/websocket",
+    ssl_context=ssl_ctx,
+)
+```
+
+The same option allows disabling certificate verification entirely – only do this for local development, never in production:
+
+```python
+import ssl
+
+ssl_ctx = ssl.create_default_context()
+ssl_ctx.check_hostname = False
+ssl_ctx.verify_mode = ssl.CERT_NONE
+
+client = Client(
+    "wss://localhost:8000/connection/websocket",
+    ssl_context=ssl_ctx,
+)
+```
+
 ## Callbacks should not block
 
 Event callbacks are called by SDK using `await` internally, the websocket connection read loop is blocked for the time SDK waits for the callback to be executed. This means that if you need to perform long operations in callbacks consider moving the work to a separate coroutine/task to return fast and continue reading data from the websocket.

--- a/centrifuge/client.py
+++ b/centrifuge/client.py
@@ -2,6 +2,7 @@ import asyncio
 import base64
 import contextlib
 import logging
+import ssl
 from asyncio import TimerHandle
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
@@ -147,6 +148,7 @@ class Client:
         max_reconnect_delay: float = 20.0,
         headers: Optional[Dict[str, str]] = None,
         loop: Optional["AbstractEventLoop"] = None,
+        ssl_context: Optional[ssl.SSLContext] = None,
     ):
         """Initializes new Client instance.
 
@@ -191,6 +193,7 @@ class Client:
         self._reconnect_timer = None
         self._headers = headers or {}
         self._server_subs: Dict[str, _ServerSubscription] = {}
+        self._ssl_context = ssl_context
 
     def subscriptions(self) -> Dict[str, "Subscription"]:
         """Returns a copy of subscriptions dict."""
@@ -306,6 +309,7 @@ class Client:
                 self._address,
                 subprotocols=subprotocols,
                 additional_headers=self._headers,
+                ssl=self._ssl_context,
             )
         except (OSError, exceptions.WebSocketException) as e:
             handler = self.events.on_error

--- a/centrifuge/client.py
+++ b/centrifuge/client.py
@@ -2,6 +2,7 @@ import asyncio
 import base64
 import contextlib
 import logging
+import ssl
 from asyncio import TimerHandle
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
@@ -153,6 +154,7 @@ class Client:
         max_reconnect_delay: float = 20.0,
         headers: Optional[Dict[str, str]] = None,
         loop: Optional["AbstractEventLoop"] = None,
+        ssl_context: Optional[ssl.SSLContext] = None,
     ):
         """Initializes new Client instance.
 
@@ -162,7 +164,15 @@ class Client:
             - connecting (when connect called, or when automatic reconnection is in progress)
             - connected (after successful connect)
         See more details about SDK behaviour in https://centrifugal.dev/docs/transports/client_api.
+
+        ssl_context customizes TLS for wss:// addresses - for example to trust a
+        custom CA or (not recommended in production) to skip certificate
+        verification. When not set, a default TLS context is used. Passing it
+        together with a ws:// address is an error.
         """
+        if ssl_context is not None and not address.lower().startswith("wss://"):
+            raise ValueError("ssl_context option is only applicable to wss:// addresses")
+
         self.state: ClientState = ClientState.DISCONNECTED
         self.events: ClientEventHandler = events or ClientEventHandler()
         self._address: str = address
@@ -196,6 +206,7 @@ class Client:
         self._reconnect_attempts = 0
         self._reconnect_timer = None
         self._headers = headers or {}
+        self._ssl_context = ssl_context
         self._server_subs: Dict[str, _ServerSubscription] = {}
         # Channel compaction: numeric channel ID -> subscription, used to route
         # pushes that carry an ID instead of the string channel name. IDs are
@@ -369,11 +380,20 @@ class Client:
             subprotocols = []
             if self._use_protobuf:
                 subprotocols = ["centrifuge-protobuf"]
+
+            connect_kwargs: Dict[str, Any] = {}
+            if self._ssl_context is not None:
+                # Only pass ssl when explicitly configured: websockets treats
+                # ssl=None as "no TLS" and raises ValueError for it on a wss://
+                # address, instead of falling back to the default TLS context.
+                connect_kwargs["ssl"] = self._ssl_context
+
             try:
                 self._conn = await websockets.connect(
                     self._address,
                     subprotocols=subprotocols,
                     additional_headers=self._headers,
+                    **connect_kwargs,
                 )
             except (OSError, exceptions.WebSocketException) as e:
                 handler = self.events.on_error

--- a/tests/fake_server.py
+++ b/tests/fake_server.py
@@ -66,6 +66,7 @@ class FakeCentrifugoServer:
     def __init__(self):
         self._server = None
         self.port = 0
+        self._secure = False
         self._current_ws = None
         # All commands received from the client, in order.
         self.received = []
@@ -78,9 +79,15 @@ class FakeCentrifugoServer:
         # Customize the subscribe result per channel: (channel, req) -> SubscribeResult.
         self.on_subscribe = None
 
-    async def start(self):
+    async def start(self, ssl_context=None):
+        """Start the server. Pass ssl_context to serve wss:// instead of ws://."""
+        self._secure = ssl_context is not None
         self._server = await websockets.serve(
-            self._handler, "localhost", 0, subprotocols=["centrifuge-protobuf"]
+            self._handler,
+            "localhost",
+            0,
+            subprotocols=["centrifuge-protobuf"],
+            ssl=ssl_context,
         )
         self.port = self._server.sockets[0].getsockname()[1]
 
@@ -91,7 +98,8 @@ class FakeCentrifugoServer:
 
     @property
     def url(self):
-        return f"ws://localhost:{self.port}/connection/websocket"
+        scheme = "wss" if self._secure else "ws"
+        return f"{scheme}://localhost:{self.port}/connection/websocket"
 
     def last_subscribe(self):
         """The most recent subscribe request, or None."""

--- a/tests/test_ssl.py
+++ b/tests/test_ssl.py
@@ -1,0 +1,118 @@
+import asyncio
+import logging
+import shutil
+import ssl
+import subprocess  # noqa: S404 - used to generate a throwaway TLS cert for tests.
+import tempfile
+import unittest
+from pathlib import Path
+
+from centrifuge import Client, ClientState
+from tests.fake_server import FakeCentrifugoServer
+
+# Tests for the ssl_context option, exercised against the in-process
+# FakeCentrifugoServer running with TLS and a throwaway self-signed certificate.
+#
+# The important regression here: ssl must NOT be passed to websockets.connect()
+# when the user did not configure a context. websockets rejects ssl=None on a
+# wss:// address with ValueError instead of falling back to the default TLS
+# context, so passing it unconditionally would break every wss:// connection.
+
+
+def _generate_cert(directory):
+    """Generate a self-signed localhost certificate, return (cert, key) paths."""
+    cert_path = Path(directory) / "cert.pem"
+    key_path = Path(directory) / "key.pem"
+    command = [
+        "openssl",
+        "req",
+        "-x509",
+        "-newkey",
+        "rsa:2048",
+        "-keyout",
+        str(key_path),
+        "-out",
+        str(cert_path),
+        "-days",
+        "1",
+        "-nodes",
+        "-subj",
+        "/CN=localhost",
+        "-addext",
+        "subjectAltName=DNS:localhost,IP:127.0.0.1",
+    ]
+    subprocess.run(command, check=True, capture_output=True)  # noqa: S603
+    return cert_path, key_path
+
+
+@unittest.skipUnless(shutil.which("openssl"), "openssl is required to generate a test cert")
+class TestSSLContext(unittest.IsolatedAsyncioTestCase):
+    async def asyncSetUp(self):
+        self._tmpdir = tempfile.TemporaryDirectory()
+        self.cert_path, key_path = _generate_cert(self._tmpdir.name)
+        server_ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+        server_ctx.load_cert_chain(self.cert_path, key_path)
+        self.server = FakeCentrifugoServer()
+        await self.server.start(ssl_context=server_ctx)
+
+    async def asyncTearDown(self):
+        await self.server.stop()
+        self._tmpdir.cleanup()
+
+    async def test_connects_to_wss_with_custom_ca(self):
+        client_ctx = ssl.create_default_context(cafile=str(self.cert_path))
+        client = Client(self.server.url, use_protobuf=True, ssl_context=client_ctx)
+        await client.connect()
+        await client.ready(timeout=5)
+        self.assertEqual(client.state, ClientState.CONNECTED)
+        await client.disconnect()
+
+    async def test_connects_to_wss_with_verification_disabled(self):
+        client_ctx = ssl.create_default_context()
+        client_ctx.check_hostname = False
+        client_ctx.verify_mode = ssl.CERT_NONE
+        client = Client(self.server.url, use_protobuf=True, ssl_context=client_ctx)
+        await client.connect()
+        await client.ready(timeout=5)
+        self.assertEqual(client.state, ClientState.CONNECTED)
+        await client.disconnect()
+
+    async def test_wss_without_ssl_context_uses_default_verification(self):
+        # Without ssl_context the default TLS context must be used: connecting to
+        # a server with a self-signed certificate fails verification and the error
+        # is reported through on_error (rather than raising ValueError from
+        # websockets, which is what passing ssl=None would do).
+        # The aborted TLS handshake makes asyncio log a server-side traceback.
+        asyncio_logger = logging.getLogger("asyncio")
+        previous_level = asyncio_logger.level
+        asyncio_logger.setLevel(logging.CRITICAL)
+        self.addCleanup(asyncio_logger.setLevel, previous_level)
+
+        error = asyncio.Future()
+
+        async def on_error(ctx):
+            if not error.done():
+                error.set_result(ctx)
+
+        client = Client(
+            self.server.url,
+            use_protobuf=True,
+            # Keep the retry far away so a single attempt is observed.
+            min_reconnect_delay=30,
+            max_reconnect_delay=30,
+        )
+        client.events.on_error = on_error
+        await client.connect()
+        ctx = await asyncio.wait_for(error, timeout=5)
+        self.assertIsInstance(ctx.error, ssl.SSLError)
+        self.assertEqual(client.state, ClientState.CONNECTING)
+        await client.disconnect()
+
+
+class TestSSLContextValidation(unittest.IsolatedAsyncioTestCase):
+    async def test_ssl_context_with_insecure_address_raises(self):
+        with self.assertRaises(ValueError):  # noqa: PT027
+            Client(
+                "ws://localhost:8000/connection/websocket",
+                ssl_context=ssl.create_default_context(),
+            )


### PR DESCRIPTION
Relates #27

Adds `ssl_context` option to `Client` constructor to customize TLS for `wss://` connections – for example to trust a custom CA:

```python
import ssl

ssl_ctx = ssl.create_default_context(cafile="/path/to/ca.pem")

client = Client(
    "wss://localhost:8000/connection/websocket",
    ssl_context=ssl_ctx,
)
```

Or to disable verification entirely (local development only):

```python
import ssl

ssl_ctx = ssl.create_default_context()
ssl_ctx.check_hostname = False
ssl_ctx.verify_mode = ssl.CERT_NONE

client = Client(
    "wss://localhost:8000/connection/websocket",
    ssl_context=ssl_ctx,
)
```

When the option is not set, behavior is unchanged: websockets creates a default TLS context with `ssl.create_default_context()`, i.e. server certificates are verified against the system CA store.

### The option must not be passed through unconditionally

An important detail: `ssl` can not simply be forwarded to `websockets.connect` on every connect, because websockets treats `ssl=None` as an explicit "no TLS" rather than "use the default context":

```python
>>> await websockets.connect("wss://example.com", ssl=None)
ValueError: ssl=None is incompatible with a wss:// URI
```

(same on websockets 14.x and 15.x)

That `ValueError` is not caught by the `except (OSError, WebSocketException)` in `_create_connection`, so it escapes from `connect()` – and from the reconnect task it would end up as an unretrieved task exception. In other words, forwarding the option as is would break every `wss://` connection for everyone not setting `ssl_context`. So `ssl` is only passed when a context is actually configured.

Additionally, passing `ssl_context` together with a `ws://` address now raises `ValueError` from the constructor – websockets rejects that combination too (`ssl argument is incompatible with a ws:// URI`), but only later, in the middle of connecting.

### Tests

`tests/test_ssl.py` runs the fake Centrifugo server with real TLS (throwaway self-signed certificate generated with `openssl`) and covers:

* connecting to `wss://` with a custom CA in `ssl_context`
* connecting to `wss://` with verification disabled
* `wss://` without `ssl_context` – default verification is used, and a self-signed certificate is reported through `on_error` (regression test for the `ssl=None` behavior above)
* `ssl_context` with a `ws://` address raising `ValueError`

`FakeCentrifugoServer.start()` accepts an optional `ssl_context` to serve `wss://`. Full suite passes on websockets 14.2 and 15.0.
