### PR TITLE
Remove deprecated loop parameter from asyncio.ensure_future calls

### DIFF
--- a/centrifuge/client.py
+++ b/centrifuge/client.py
@@ -444,7 +444,7 @@ class Client:
                             self._refresh_timer.cancel()
                         self._refresh_timer = self._loop.call_later(
                             ttl,
-                            lambda: asyncio.ensure_future(self._refresh(), loop=self._loop),
+                            lambda: asyncio.ensure_future(self._refresh()),
                         )
 
                     self._connected_future.set_result(True)
@@ -653,7 +653,7 @@ class Client:
                 self._refresh_timer.cancel()
             self._refresh_timer = self._loop.call_later(
                 ttl,
-                lambda: asyncio.ensure_future(self._refresh(), loop=self._loop),
+                lambda: asyncio.ensure_future(self._refresh()),
             )
 
     async def _sub_refresh(self, channel: str):
@@ -726,7 +726,7 @@ class Client:
                 sub._refresh_timer.cancel()
             sub._refresh_timer = self._loop.call_later(
                 ttl,
-                lambda: asyncio.ensure_future(sub._refresh(), loop=self._loop),
+                lambda: asyncio.ensure_future(sub._refresh()),
             )
 
     @staticmethod
@@ -1238,7 +1238,7 @@ class Client:
             self._ping_timer.cancel()
         self._ping_timer = self._loop.call_later(
             self._ping_interval + self._max_server_ping_delay,
-            lambda: asyncio.ensure_future(self._no_ping(), loop=self._loop),
+            lambda: asyncio.ensure_future(self._no_ping()),
         )
 
     async def _handle_ping(self) -> None:
@@ -1681,7 +1681,7 @@ class Subscription:
                 self._refresh_timer.cancel()
             self._refresh_timer = self._client._loop.call_later(
                 ttl,
-                lambda: asyncio.ensure_future(self._refresh(), loop=self._client._loop),
+                lambda: asyncio.ensure_future(self._refresh()),
             )
 
         self._delta_negotiated = subscribe.get("delta", False)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -648,7 +648,7 @@ class TestConnectionLeak(unittest.IsolatedAsyncioTestCase):
                     client._refresh_timer.cancel()
                 client._refresh_timer = client._loop.call_later(
                     10.0,
-                    lambda: asyncio.ensure_future(client._refresh(), loop=client._loop),
+                    lambda: asyncio.ensure_future(client._refresh()),
                 )
 
             # Count new refresh timers created


### PR DESCRIPTION
## Summary

- Remove the `loop=` parameter from 5 `asyncio.ensure_future()` calls in `client.py` and 1 in `test_client.py`
- The `loop` parameter was deprecated in Python 3.10 and **removed in Python 3.12**, causing `TypeError` at runtime
- These calls are inside `call_later` lambdas (refresh timers, ping timeout, subscription refresh), so they crash when timers fire — not on import, which is why the bug may have gone unnoticed
- The project supports Python 3.9–3.13 per `pyproject.toml`, so this fix is required for Python 3.12+ compatibility

## Test plan

- [x] Verified no `loop=` parameter remains in any `asyncio.ensure_future()` call
- [ ] Run existing test suite against Python 3.12+

🤖 Generated with [Claude Code](https://claude.com/claude-code)