### PR TITLE
Support publication filtering by tags

### DIFF
--- a/centrifuge/__init__.py
+++ b/centrifuge/__init__.py
@@ -1,6 +1,7 @@
 """Main module of a Centrifuge Python client library."""
 
 from .client import Client, ClientState, Subscription, SubscriptionState, DeltaType
+from .filter import Filter, FilterNode
 from .contexts import (
     ConnectedContext,
     ConnectingContext,
@@ -54,6 +55,8 @@ __all__ = [
     "DisconnectedContext",
     "DuplicateSubscriptionError",
     "ErrorContext",
+    "Filter",
+    "FilterNode",
     "HistoryResult",
     "JoinContext",
     "LeaveContext",

--- a/centrifuge/client.py
+++ b/centrifuge/client.py
@@ -22,6 +22,7 @@ from websockets import exceptions
 from websockets.protocol import State
 
 from centrifuge.codecs import _JsonCodec, _ProtobufCodec
+from centrifuge.filter import FilterNode
 from centrifuge.codes import (
     _ERROR_CODE_UNRECOVERABLE_POSITION,
     _SUBSCRIPTION_FLAG_CHANNEL_COMPACTION,
@@ -222,10 +223,16 @@ class Client:
         recoverable: bool = False,
         join_leave: bool = False,
         delta: Optional[DeltaType] = None,
+        tags_filter: Optional[FilterNode] = None,
         get_state: Optional[Callable[[str], Awaitable[StreamPosition]]] = None,
     ) -> "Subscription":
         """Creates new subscription to channel. If subscription already exists then
         DuplicateSubscriptionError exception will be raised.
+
+        tags_filter sets a server-side publication filter based on publication
+        tags: the server delivers only publications whose tags match the filter.
+        It must be enabled for the namespace on the server (allow_tags_filter)
+        and cannot be combined with delta. Build it with the Filter helpers.
 
         get_state is called to load the app's current state and stream position.
         Requires Centrifugo >= 6.8.0.
@@ -275,6 +282,7 @@ class Client:
             recoverable=recoverable,
             join_leave=join_leave,
             delta=delta,
+            tags_filter=tags_filter,
             get_state=get_state,
         )
         self._subs[channel] = sub
@@ -972,6 +980,9 @@ class Client:
         if sub._delta:
             subscribe["delta"] = sub._delta.value
 
+        if sub._tags_filter is not None:
+            subscribe["tf"] = sub._tags_filter.node
+
         command = {
             "id": cmd_id,
             "subscribe": subscribe,
@@ -1611,6 +1622,7 @@ class Subscription:
         recoverable: bool = False,
         join_leave: bool = False,
         delta: Optional[DeltaType] = None,
+        tags_filter: Optional[FilterNode] = None,
         get_state: Optional[Callable[[str], Awaitable[StreamPosition]]] = None,
     ) -> None:
         """Initializes Subscription instance.
@@ -1644,8 +1656,11 @@ class Subscription:
 
         if delta and delta not in {DeltaType.FOSSIL}:
             raise CentrifugeError("unsupported delta format")
+        if delta and tags_filter is not None:
+            raise CentrifugeError("cannot use delta and tags filter together")
         self._delta = delta
         self._delta_negotiated: bool = False
+        self._tags_filter = tags_filter
 
     @classmethod
     def _create_instance(cls, *args: Any, **kwargs: Any) -> "Subscription":
@@ -1696,6 +1711,15 @@ class Subscription:
         await self.ready(timeout=timeout)
         # noinspection PyProtectedMember
         return await self._client.publish(self.channel, data, timeout=timeout)
+
+    def set_tags_filter(self, tags_filter: Optional[FilterNode]) -> None:
+        """Sets the server-side publication tags filter. Applied on the next
+        subscribe attempt, not the current one. Pass None to clear it. Cannot be
+        combined with delta compression. Build with the Filter helpers.
+        """
+        if tags_filter is not None and self._delta:
+            raise CentrifugeError("cannot use delta and tags filter together")
+        self._tags_filter = tags_filter
 
     async def subscribe(self) -> None:
         if self.state == SubscriptionState.SUBSCRIBING:

--- a/centrifuge/filter.py
+++ b/centrifuge/filter.py
@@ -1,0 +1,136 @@
+"""Builders for server-side publication filtering by publication tags.
+
+A filter is either a leaf node (a comparison such as ``ticker == "AAPL"``) or a
+logical node combining child nodes with and/or/not. The server evaluates the
+filter against each publication's tags and delivers only matching publications.
+See https://centrifugal.dev/docs/server/publication_filtering.
+
+Publication filtering must be enabled for the namespace on the server
+(``allow_tags_filter``) and cannot be combined with delta compression.
+
+Build leaf comparisons with the :class:`Filter` helpers and combine them with
+:meth:`Filter.all` (AND), :meth:`Filter.any` (OR) and :meth:`Filter.negate`
+(NOT). Pass the result via ``Client.new_subscription(..., tags_filter=...)`` or
+``Subscription.set_tags_filter(...)``::
+
+    # (ticker == "AAPL") AND (price >= "100") AND (source in ["NASDAQ", "NYSE"])
+    tags_filter = Filter.all(
+        Filter.eq("ticker", "AAPL"),
+        Filter.gte("price", "100"),
+        Filter.is_in("source", ["NASDAQ", "NYSE"]),
+    )
+
+    # NOT (source == "NYSE")
+    tags_filter = Filter.negate(Filter.eq("source", "NYSE"))
+"""
+
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
+
+
+@dataclass(frozen=True)
+class FilterNode:
+    """A node in a publication tags-filter expression tree. Build with :class:`Filter`."""
+
+    node: Dict[str, Any]
+
+
+class Filter:
+    """Static builders for :class:`FilterNode` expressions.
+
+    Comparison helpers (:meth:`eq`, :meth:`is_in`, ...) create leaf nodes;
+    :meth:`all`, :meth:`any` and :meth:`negate` combine them.
+    """
+
+    @staticmethod
+    def _leaf(key: str, cmp: str, val: str = "", vals: Optional[List[str]] = None) -> FilterNode:
+        node: Dict[str, Any] = {"key": key, "cmp": cmp}
+        if val:
+            node["val"] = val
+        if vals:
+            node["vals"] = list(vals)
+        return FilterNode(node)
+
+    @staticmethod
+    def _logical(op: str, nodes: List[FilterNode]) -> FilterNode:
+        return FilterNode({"op": op, "nodes": [n.node for n in nodes]})
+
+    @staticmethod
+    def eq(key: str, val: str) -> FilterNode:
+        """Tag ``key`` equals ``val``."""
+        return Filter._leaf(key, "eq", val=val)
+
+    @staticmethod
+    def neq(key: str, val: str) -> FilterNode:
+        """Tag ``key`` does not equal ``val``."""
+        return Filter._leaf(key, "neq", val=val)
+
+    @staticmethod
+    def is_in(key: str, vals: List[str]) -> FilterNode:
+        """Tag ``key`` is one of ``vals``."""
+        return Filter._leaf(key, "in", vals=vals)
+
+    @staticmethod
+    def not_in(key: str, vals: List[str]) -> FilterNode:
+        """Tag ``key`` is not one of ``vals``."""
+        return Filter._leaf(key, "nin", vals=vals)
+
+    @staticmethod
+    def exists(key: str) -> FilterNode:
+        """Tag ``key`` exists."""
+        return Filter._leaf(key, "ex")
+
+    @staticmethod
+    def not_exists(key: str) -> FilterNode:
+        """Tag ``key`` does not exist."""
+        return Filter._leaf(key, "nex")
+
+    @staticmethod
+    def starts_with(key: str, val: str) -> FilterNode:
+        """String tag ``key`` starts with ``val``."""
+        return Filter._leaf(key, "sw", val=val)
+
+    @staticmethod
+    def ends_with(key: str, val: str) -> FilterNode:
+        """String tag ``key`` ends with ``val``."""
+        return Filter._leaf(key, "ew", val=val)
+
+    @staticmethod
+    def contains(key: str, val: str) -> FilterNode:
+        """String tag ``key`` contains ``val``."""
+        return Filter._leaf(key, "ct", val=val)
+
+    @staticmethod
+    def gt(key: str, val: str) -> FilterNode:
+        """Numeric tag ``key`` is greater than ``val``."""
+        return Filter._leaf(key, "gt", val=val)
+
+    @staticmethod
+    def gte(key: str, val: str) -> FilterNode:
+        """Numeric tag ``key`` is greater than or equal to ``val``."""
+        return Filter._leaf(key, "gte", val=val)
+
+    @staticmethod
+    def lt(key: str, val: str) -> FilterNode:
+        """Numeric tag ``key`` is less than ``val``."""
+        return Filter._leaf(key, "lt", val=val)
+
+    @staticmethod
+    def lte(key: str, val: str) -> FilterNode:
+        """Numeric tag ``key`` is less than or equal to ``val``."""
+        return Filter._leaf(key, "lte", val=val)
+
+    @staticmethod
+    def all(*nodes: FilterNode) -> FilterNode:
+        """All ``nodes`` must match (logical AND)."""
+        return Filter._logical("and", list(nodes))
+
+    @staticmethod
+    def any(*nodes: FilterNode) -> FilterNode:
+        """At least one of ``nodes`` must match (logical OR)."""
+        return Filter._logical("or", list(nodes))
+
+    @staticmethod
+    def negate(node: FilterNode) -> FilterNode:
+        """Inverts ``node`` (logical NOT)."""
+        return Filter._logical("not", [node])

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -1,0 +1,179 @@
+import asyncio
+import unittest
+
+from centrifuge import Client, DeltaType, Filter
+from centrifuge.exceptions import CentrifugeError
+from tests.fake_server import FakeCentrifugoServer
+
+# Tests for publication filtering (server-side filtering by publication tags).
+# The Filter builders construct a FilterNode dict tree; the subscribe request
+# carries it in the `tf` field. The feature requires Centrifugo PRO / namespace
+# config, so wire-level behavior is exercised against the in-process
+# FakeCentrifugoServer.
+
+
+class TestFilterBuilder(unittest.TestCase):
+    def test_comparison_leaf_nodes(self):
+        self.assertEqual(Filter.eq("t", "AAPL").node, {"key": "t", "cmp": "eq", "val": "AAPL"})
+        self.assertEqual(Filter.neq("a", "b").node, {"key": "a", "cmp": "neq", "val": "b"})
+        self.assertEqual(Filter.exists("price").node, {"key": "price", "cmp": "ex"})
+        self.assertEqual(Filter.not_exists("id").node, {"key": "id", "cmp": "nex"})
+        self.assertEqual(Filter.starts_with("t", "A").node, {"key": "t", "cmp": "sw", "val": "A"})
+        self.assertEqual(Filter.ends_with("s", "Q").node, {"key": "s", "cmp": "ew", "val": "Q"})
+        self.assertEqual(Filter.contains("c", "ec").node, {"key": "c", "cmp": "ct", "val": "ec"})
+        self.assertEqual(Filter.gt("price", "100").node["cmp"], "gt")
+        self.assertEqual(Filter.gte("volume", "1000").node["cmp"], "gte")
+        self.assertEqual(Filter.lt("price", "200").node["cmp"], "lt")
+        self.assertEqual(Filter.lte("volume", "1000").node["cmp"], "lte")
+
+    def test_set_membership_nodes(self):
+        self.assertEqual(
+            Filter.is_in("category", ["tech", "finance"]).node,
+            {"key": "category", "cmp": "in", "vals": ["tech", "finance"]},
+        )
+        self.assertEqual(
+            Filter.not_in("ticker", ["MSFT", "GOOGL"]).node,
+            {"key": "ticker", "cmp": "nin", "vals": ["MSFT", "GOOGL"]},
+        )
+
+    def test_logical_nodes(self):
+        and_node = Filter.all(
+            Filter.eq("ticker", "AAPL"),
+            Filter.gte("price", "100"),
+            Filter.is_in("source", ["NASDAQ", "NYSE"]),
+        ).node
+        self.assertEqual(and_node["op"], "and")
+        self.assertEqual(len(and_node["nodes"]), 3)
+        self.assertEqual(and_node["nodes"][0]["key"], "ticker")
+        self.assertEqual(and_node["nodes"][2]["cmp"], "in")
+
+        or_node = Filter.any(Filter.eq("ticker", "MSFT"), Filter.eq("category", "tech")).node
+        self.assertEqual(or_node["op"], "or")
+        self.assertEqual(len(or_node["nodes"]), 2)
+
+        not_node = Filter.negate(Filter.eq("source", "NYSE")).node
+        self.assertEqual(not_node["op"], "not")
+        self.assertEqual(len(not_node["nodes"]), 1)
+        self.assertEqual(not_node["nodes"][0]["cmp"], "eq")
+
+    def test_nested_logical_nodes(self):
+        # NOT ( (ticker == AAPL) AND (category in [tech, finance]) )
+        node = Filter.negate(
+            Filter.all(
+                Filter.eq("ticker", "AAPL"),
+                Filter.is_in("category", ["tech", "finance"]),
+            )
+        ).node
+        self.assertEqual(node["op"], "not")
+        self.assertEqual(len(node["nodes"]), 1)
+        self.assertEqual(node["nodes"][0]["op"], "and")
+        self.assertEqual(len(node["nodes"][0]["nodes"]), 2)
+
+
+class TestTagsFilterWire(unittest.IsolatedAsyncioTestCase):
+    async def asyncSetUp(self):
+        self.server = FakeCentrifugoServer()
+        await self.server.start()
+
+    async def asyncTearDown(self):
+        await self.server.stop()
+
+    def _make_client(self):
+        return Client(self.server.url, use_protobuf=True)
+
+    async def test_subscribe_request_carries_tags_filter(self):
+        client = self._make_client()
+        sub = client.new_subscription(
+            "market:stocks",
+            tags_filter=Filter.all(
+                Filter.eq("ticker", "AAPL"),
+                Filter.gte("price", "100"),
+            ),
+        )
+        subscribed = asyncio.Future()
+
+        async def on_subscribed(ctx):
+            if not subscribed.done():
+                subscribed.set_result(ctx)
+
+        sub.events.on_subscribed = on_subscribed
+        await client.connect()
+        await sub.subscribe()
+        await asyncio.wait_for(subscribed, timeout=5)
+
+        tf = self.server.last_subscribe().tf
+        self.assertEqual(tf.op, "and")
+        self.assertEqual(len(tf.nodes), 2)
+        self.assertEqual(tf.nodes[0].key, "ticker")
+        self.assertEqual(tf.nodes[0].cmp, "eq")
+        self.assertEqual(tf.nodes[0].val, "AAPL")
+        self.assertEqual(tf.nodes[1].cmp, "gte")
+        await client.disconnect()
+
+    async def test_set_tags_filter_applies_on_subscribe(self):
+        client = self._make_client()
+        sub = client.new_subscription("market:stocks")
+        sub.set_tags_filter(Filter.eq("ticker", "BTC"))
+        subscribed = asyncio.Future()
+
+        async def on_subscribed(ctx):
+            if not subscribed.done():
+                subscribed.set_result(ctx)
+
+        sub.events.on_subscribed = on_subscribed
+        await client.connect()
+        await sub.subscribe()
+        await asyncio.wait_for(subscribed, timeout=5)
+
+        tf = self.server.last_subscribe().tf
+        self.assertEqual(tf.key, "ticker")
+        self.assertEqual(tf.val, "BTC")
+        await client.disconnect()
+
+    async def test_subscribe_without_filter_sends_no_tf(self):
+        client = self._make_client()
+        sub = client.new_subscription("market:stocks")
+        subscribed = asyncio.Future()
+
+        async def on_subscribed(ctx):
+            if not subscribed.done():
+                subscribed.set_result(ctx)
+
+        sub.events.on_subscribed = on_subscribed
+        await client.connect()
+        await sub.subscribe()
+        await asyncio.wait_for(subscribed, timeout=5)
+
+        self.assertFalse(self.server.last_subscribe().HasField("tf"))
+        await client.disconnect()
+
+
+class TestTagsFilterValidation(unittest.IsolatedAsyncioTestCase):
+    async def test_new_subscription_rejects_delta_with_tags_filter(self):
+        client = Client("ws://localhost:0/connection/websocket")
+        err = None
+        try:
+            client.new_subscription(
+                "market:stocks",
+                delta=DeltaType.FOSSIL,
+                tags_filter=Filter.eq("ticker", "AAPL"),
+            )
+        except CentrifugeError as e:
+            err = e
+        self.assertIsNotNone(err, "expected CentrifugeError for delta + tags filter")
+        self.assertIn("tags filter", str(err))
+
+    async def test_set_tags_filter_rejects_delta_combination(self):
+        client = Client("ws://localhost:0/connection/websocket")
+        sub = client.new_subscription("market:stocks", delta=DeltaType.FOSSIL)
+        err = None
+        try:
+            sub.set_tags_filter(Filter.eq("ticker", "AAPL"))
+        except CentrifugeError as e:
+            err = e
+        self.assertIsNotNone(err, "expected CentrifugeError for delta + tags filter")
+        self.assertIn("tags filter", str(err))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds support for [publication filtering](https://centrifugal.dev/docs/server/publication_filtering) by publication tags.

A subscription can carry a tags filter so the server delivers only publications whose tags match it — reducing bandwidth and client-side processing.

### API

- `Filter` builders: `eq`, `neq`, `is_in`, `not_in`, `exists`, `not_exists`, `starts_with`, `ends_with`, `contains`, `gt`, `gte`, `lt`, `lte`, and the combinators `all`, `any`, `negate`.
- `Client.new_subscription(..., tags_filter=...)` to set at creation.
- `Subscription.set_tags_filter(...)` to set/replace before the next subscribe (pass `None` to clear).
- Mutually exclusive with delta compression (validated).

### Example

```python
sub = client.new_subscription("market:stocks", tags_filter=Filter.all(
    Filter.eq("ticker", "AAPL"),
    Filter.gte("price", "100"),
    Filter.is_in("source", ["NASDAQ", "NYSE"]),
))
```

Tests added in `tests/test_filter.py`: builder unit tests plus fake-server wire tests asserting the subscribe request carries the `tf` field (and sends none when unset).
