### PR TITLE
Support state invalidation

### DIFF
--- a/centrifuge/client.py
+++ b/centrifuge/client.py
@@ -24,9 +24,11 @@ from websockets.protocol import State
 from centrifuge.codecs import _JsonCodec, _ProtobufCodec
 from centrifuge.filter import FilterNode
 from centrifuge.codes import (
+    _DISCONNECTED_STATE_INVALIDATED,
     _ERROR_CODE_UNRECOVERABLE_POSITION,
     _SUBSCRIPTION_FLAG_CHANNEL_COMPACTION,
     _SUBSCRIPTION_FLAG_REJECT_UNRECOVERED,
+    _UNSUBSCRIBED_STATE_INVALIDATED,
     _ConnectingCode,
     _DisconnectedCode,
     _ErrorCode,
@@ -1287,10 +1289,22 @@ class Client:
             return
         self._disconnecting = True
 
+        if code == _DISCONNECTED_STATE_INVALIDATED:
+            # State invalidated (delivered as a WebSocket close frame or a
+            # Disconnect push, both funnel here): drop the connection token so the
+            # next connect fetches a fresh one via get_token, and invalidate every
+            # subscription's cached state before reconnecting.
+            self._invalidate_connection_state()
+
         try:
             await self._do_disconnect(code, reason, reconnect)
         finally:
             self._disconnecting = False
+
+    def _invalidate_connection_state(self) -> None:
+        self._token = ""
+        for sub in self._subs.values():
+            sub._invalidate_state()
 
     async def _do_disconnect(self, code: int, reason: str, reconnect: bool) -> None:
         if self._ping_timer:
@@ -1405,6 +1419,10 @@ class Client:
             if code < 2500:
                 asyncio.ensure_future(sub._move_unsubscribed(code, unsubscribe["reason"]))
             else:
+                if code == _UNSUBSCRIBED_STATE_INVALIDATED:
+                    # State invalidated: drop the subscription token and cached
+                    # state so the resubscribe obtains a fresh token and re-syncs.
+                    sub._invalidate_state()
                 asyncio.ensure_future(sub._move_subscribing(code, unsubscribe["reason"]))
         else:
             server_sub = self._server_subs.get(channel)
@@ -1950,3 +1968,21 @@ class Subscription:
         old_id = self._push_id
         self._push_id = push_id
         self._client._update_subscription_push_id(self, old_id, push_id)
+
+    def _invalidate_state(self) -> None:
+        # Reset cached subscription state on "state invalidated" (unsubscribe code
+        # 2502 or connection disconnect code 3014) so the resubscribe re-syncs:
+        # clear the token (next subscribe fetches a fresh one via get_token), the
+        # fossil delta base (a stale base would corrupt decoding of the first
+        # publication), and the channel-compaction ID mapping. The recovery
+        # position is reset to a sentinel epoch ("_") the server can never match
+        # (offset 0); the recover flag is left untouched. So a recoverable
+        # subscription resubscribes with was_recovering=True, recovered=False —
+        # letting the app reload via its existing recovery-failure path — while a
+        # non-recoverable one just resubscribes (the sentinel is not sent). The
+        # real epoch/offset are adopted from the subscribe reply.
+        self._token = ""
+        self._offset = 0
+        self._epoch = "_"
+        self._prev_data = None
+        self._set_push_id(0)

--- a/centrifuge/codes.py
+++ b/centrifuge/codes.py
@@ -80,3 +80,12 @@ _SUBSCRIPTION_FLAG_REJECT_UNRECOVERED = 2
 # Server error code returned when recovery from the provided position is
 # impossible (only sent when _SUBSCRIPTION_FLAG_REJECT_UNRECOVERED was requested).
 _ERROR_CODE_UNRECOVERABLE_POSITION = 112
+
+# Server-sent "state invalidated" codes. The server determines that the client's
+# cached state and/or token are no longer valid and asks the client to drop them
+# and re-sync. 2502 arrives in an Unsubscribe push for a single subscription (the
+# client clears the subscription state and resubscribes, since it's >= 2500); 3014
+# arrives for the whole connection (the client clears the connection token to force
+# a fresh one via get_token, invalidates all subscriptions, reconnects).
+_UNSUBSCRIBED_STATE_INVALIDATED = 2502
+_DISCONNECTED_STATE_INVALIDATED = 3014

--- a/tests/fake_server.py
+++ b/tests/fake_server.py
@@ -106,6 +106,13 @@ class FakeCentrifugoServer:
         if self._current_ws is not None:
             await self._current_ws.close()
 
+    async def disconnect_close(self, code, reason):
+        """Close the active connection with a specific code, the way Centrifugo
+        delivers a server disconnect (e.g. 3014 state invalidated) — as a
+        WebSocket close frame rather than a Disconnect push."""
+        if self._current_ws is not None:
+            await self._current_ws.close(code=code, reason=reason)
+
     async def _handler(self, websocket):
         self._current_ws = websocket
         try:

--- a/tests/test_state_invalidation.py
+++ b/tests/test_state_invalidation.py
@@ -1,0 +1,134 @@
+import asyncio
+import unittest
+
+from centrifuge import Client
+from tests.fake_server import FakeCentrifugoServer
+
+# Tests for "state invalidated" handling: unsubscribe code 2502 (per-subscription)
+# and disconnect code 3014 (connection-wide). On these the client drops cached
+# tokens (and recovery position / delta base) so a fresh token is obtained and
+# the subscription re-syncs. Exercised against the in-process FakeCentrifugoServer.
+
+_STATE_INVALIDATED_UNSUBSCRIBE = 2502
+_STATE_INVALIDATED_DISCONNECT = 3014
+
+
+class TestInvalidateStateUnit(unittest.IsolatedAsyncioTestCase):
+    async def test_invalidate_state_resets_cached_state(self):
+        client = Client("ws://localhost:0/connection/websocket")
+        sub = client.new_subscription("ch", token="sub-token")  # noqa: S106
+        sub._offset = 10
+        sub._epoch = "e1"
+        sub._recover = True
+        sub._prev_data = b"stale-delta-base"
+
+        sub._invalidate_state()
+
+        self.assertEqual(sub._token, "")
+        self.assertEqual(sub._offset, 0)
+        # Recovery position reset to the sentinel epoch so a recoverable
+        # subscription resubscribes with was_recovering=True, recovered=False.
+        self.assertEqual(sub._epoch, "_")
+        # The recover flag is left untouched (here it stays True; for a
+        # non-recoverable subscription it would stay False).
+        self.assertTrue(sub._recover)
+        self.assertIsNone(sub._prev_data)
+
+
+class TestStateInvalidationWire(unittest.IsolatedAsyncioTestCase):
+    async def asyncSetUp(self):
+        self.server = FakeCentrifugoServer()
+        await self.server.start()
+
+    async def asyncTearDown(self):
+        await self.server.stop()
+
+    @staticmethod
+    def _subscribed_future(sub):
+        fut = asyncio.Future()
+
+        async def on_subscribed(ctx):
+            if not fut.done():
+                fut.set_result(ctx)
+
+        sub.events.on_subscribed = on_subscribed
+        return fut
+
+    async def test_unsubscribe_2502_clears_sub_token_and_resubscribes(self):
+        client = Client(self.server.url, use_protobuf=True, min_reconnect_delay=0.05)
+        sub = client.new_subscription("ch", token="sub-token-0")  # noqa: S106
+        subscribed = self._subscribed_future(sub)
+        await client.connect()
+        await sub.subscribe()
+        await asyncio.wait_for(subscribed, timeout=5)
+        self.assertEqual(self.server.last_subscribe().token, "sub-token-0")
+
+        # Re-arm the future for the resubscribe and send "state invalidated".
+        resubscribed = self._subscribed_future(sub)
+        await self.server.unsubscribe("ch", _STATE_INVALIDATED_UNSUBSCRIBE, "state invalidated")
+        await asyncio.wait_for(resubscribed, timeout=5)
+
+        self.assertEqual(sub._token, "")
+        self.assertEqual(self.server.last_subscribe().token, "")
+        await client.disconnect()
+
+    async def test_disconnect_3014_clears_conn_token_and_invalidates_subs(self):
+        calls = []
+
+        async def get_token():
+            calls.append(1)
+            return "conn-token-1"
+
+        client = Client(
+            self.server.url,
+            use_protobuf=True,
+            token="conn-token-0",  # noqa: S106
+            get_token=get_token,
+            min_reconnect_delay=0.05,
+            max_reconnect_delay=0.2,
+        )
+        sub = client.new_subscription("ch", token="sub-token-0")  # noqa: S106
+        subscribed = self._subscribed_future(sub)
+
+        connected = asyncio.Future()
+
+        async def on_connected(ctx):
+            if not connected.done():
+                connected.set_result(ctx)
+
+        client.events.on_connected = on_connected
+        await client.connect()
+        await asyncio.wait_for(connected, timeout=5)
+        await sub.subscribe()
+        await asyncio.wait_for(subscribed, timeout=5)
+
+        # Re-arm for the post-reconnect connected + resubscribed.
+        reconnected = asyncio.Future()
+
+        async def on_reconnected(ctx):
+            if not reconnected.done():
+                reconnected.set_result(ctx)
+
+        client.events.on_connected = on_reconnected
+        resubscribed = self._subscribed_future(sub)
+
+        # Server delivers "state invalidated" as a close frame (as Centrifugo does).
+        await self.server.disconnect_close(_STATE_INVALIDATED_DISCONNECT, "state invalidated")
+
+        await asyncio.wait_for(reconnected, timeout=5)
+        await asyncio.wait_for(resubscribed, timeout=5)
+
+        self.assertGreaterEqual(len(calls), 1, "get_token must be called after 3014")
+        # Reconnect used the freshly fetched connection token.
+        last_connect = None
+        for cmd in self.server.received:
+            if cmd.HasField("connect"):
+                last_connect = cmd.connect
+        self.assertEqual(last_connect.token, "conn-token-1")
+        # Subscription was invalidated — resubscribe carries no token.
+        self.assertEqual(self.server.last_subscribe().token, "")
+        await client.disconnect()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Handles server "state invalidated" signals so clients drop stale cached state and re-sync:

- **Unsubscribe code 2502** (per-subscription): clears the subscription token and cached state, then resubscribes.
- **Disconnect code 3014** (connection-wide): clears the connection token (forcing a fresh one via `get_token`), invalidates every subscription, and reconnects. Funneled through `_disconnect`, so it fires from **both** the Disconnect push and the WebSocket close frame.

`_invalidate_state` clears the token, fossil delta base and channel-compaction id, and resets the recovery position to a sentinel epoch (`"_"`, offset 0) the server can never match — leaving the `recover` flag untouched. So a recoverable subscription resubscribes with `was_recovering=True, recovered=False` (the app reloads via its existing recovery-failure path), while a non-recoverable one just resubscribes. The real epoch/offset are adopted from the subscribe reply.

Tests in `tests/test_state_invalidation.py` (run under `unittest`): `_invalidate_state` unit, 2502 resubscribe, 3014 connection-token refresh + sub invalidation.
