### PR TITLE
Require websockets >= 14.1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,8 @@ jobs:
           - "5.29.3"
           - "6.31.0"
         websockets-version:
-          - "14.2"
+          # Lowest supported version (see pyproject.toml) and the latest one.
+          - "14.1"
           - "15.0"
 
     runs-on: ${{ matrix.os }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,11 @@ classifiers = [
     "Typing :: Typed",
 ]
 dependencies = [
-    "websockets>=14.0.0,<16.0.0",
+    # 14.1 is the floor: Connection.close_code / close_reason, which the client
+    # uses to turn a server close frame into a disconnect code, only appeared
+    # there - on 14.0 the client raises AttributeError on close and reconnects
+    # in a loop instead of handling terminal disconnect codes.
+    "websockets>=14.1,<16.0.0",
     "protobuf>=4.23.4,<7.0.0",
 ]
 


### PR DESCRIPTION
`pyproject.toml` allowed `websockets>=14.0.0`, but the client can not work with 14.0: `Connection.close_code` / `close_reason` – which `_listen` uses to turn a server close frame into a disconnect code – only appeared in websockets 14.1.

On 14.0 the read loop dies with `AttributeError` as soon as the connection is closed. The exception is stored in the never-awaited listen task, so it is completely silent:

```
websockets=14.0  state=CONNECTED     disconnected_codes=[]
                 listen task: AttributeError("'ClientConnection' object has no attribute 'close_code'")
websockets=14.1  state=DISCONNECTED  disconnected_codes=[3500]
```

(client connected to a server which then closed the connection with code 3500)

I.e. with websockets 14.0 the client stays in `connected` state after the connection is gone, `on_disconnected` is never called, and terminal disconnect codes (3500 invalid token, 3501 bad request, ...) are never handled – the client keeps reconnecting instead of stopping. Running the test suite against 14.0 hangs in `TestClientTokenInvalid` for this reason.

CI matrix tested 14.2 and 15.0, so the broken lower bound went unnoticed. This PR:

* raises the requirement to `websockets>=14.1,<16.0.0`
* runs CI with 14.1 instead of 14.2, so the lowest supported version is the one actually exercised
