### PR TITLE
Add proxy option to Client

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,27 @@ client = Client(
 )
 ```
 
+## Connecting through a proxy
+
+By default the proxy configuration is taken from the environment (`WS_PROXY`/`WSS_PROXY`, `HTTP_PROXY`/`HTTPS_PROXY`, honoring `NO_PROXY`). To set the proxy explicitly – use `proxy` option of `Client` constructor:
+
+```python
+client = Client(
+    "ws://localhost:8000/connection/websocket",
+    proxy="http://user:pass@proxy-host:3128",
+)
+```
+
+Pass `proxy=None` to always connect directly, ignoring the environment configuration.
+
+SOCKS proxies (`socks5://...`) are supported too, but require the [python-socks](https://pypi.org/project/python-socks/) package to be installed:
+
+```bash
+pip install python-socks
+```
+
+Note that the `proxy` option requires `websockets` >= 15.0 – passing it with an older version raises `ValueError`.
+
 ## Callbacks should not block
 
 Event callbacks are called by SDK using `await` internally, the websocket connection read loop is blocked for the time SDK waits for the callback to be executed. This means that if you need to perform long operations in callbacks consider moving the work to a separate coroutine/task to return fast and continue reading data from the websocket.

--- a/README.md
+++ b/README.md
@@ -90,7 +90,12 @@ SOCKS proxies (`socks5://...`) are supported too, but require the [python-socks]
 pip install python-socks
 ```
 
-Note that the `proxy` option requires `websockets` >= 15.0 – passing it with an older version raises `ValueError`.
+Proxy support in `websockets` appeared in version 15.0 – with older versions the client always connects directly, ignoring both the `proxy` option and the environment configuration. Setting a proxy URL there raises `ValueError` from the `Client` constructor, so that the option does not silently do nothing. Invalid proxy URLs and a missing `python-socks` package are reported the same way.
+
+A couple of things to keep in mind when going through a proxy:
+
+* with a `wss://` address the proxy only sees the `CONNECT host:port` request – the WebSocket traffic inside the tunnel stays encrypted end to end, and the server certificate is still verified as usual. With a `ws://` address the proxy sees everything, including the connection token.
+* credentials in an `http://` proxy URL are sent to the proxy as a base64-encoded `Proxy-Authorization` header over an unencrypted connection. They are never forwarded to the Centrifugo server, but use an `https://` proxy if the proxy connection itself may be observed.
 
 ## Callbacks should not block
 

--- a/centrifuge/client.py
+++ b/centrifuge/client.py
@@ -12,6 +12,7 @@ from typing import (
     Any,
     Awaitable,
     Dict,
+    Literal,
     Optional,
     Union,
     List,
@@ -94,6 +95,21 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger("centrifuge")
 
+# The proxy argument of websockets.connect() appeared in websockets 15.0, while
+# this SDK still supports websockets 14.x - so the option is validated upfront to
+# fail with a clear message instead of a TypeError from deep inside websockets.
+_PROXY_MIN_WEBSOCKETS_VERSION = (15, 0)
+
+
+def _websockets_supports_proxy() -> bool:
+    try:
+        major, minor = (int(part) for part in websockets.__version__.split(".")[:2])
+    except ValueError:
+        # Unexpected version format (development build?) - assume support and let
+        # websockets complain if the option is not there.
+        return True
+    return (major, minor) >= _PROXY_MIN_WEBSOCKETS_VERSION
+
 
 class ClientState(Enum):
     """ClientState represents possible states of Client connection."""
@@ -155,6 +171,7 @@ class Client:
         headers: Optional[Dict[str, str]] = None,
         loop: Optional["AbstractEventLoop"] = None,
         ssl_context: Optional[ssl.SSLContext] = None,
+        proxy: Union[str, Literal[True], None] = True,
     ):
         """Initializes new Client instance.
 
@@ -169,9 +186,22 @@ class Client:
         custom CA or (not recommended in production) to skip certificate
         verification. When not set, a default TLS context is used. Passing it
         together with a ws:// address is an error.
+
+        proxy sets the proxy to connect through, in the form
+        "http://user:pass@host:port" ("socks5://..." also works, but requires the
+        python-socks package to be installed). By default proxy configuration is
+        taken from the environment (WS_PROXY/WSS_PROXY, HTTP_PROXY/HTTPS_PROXY,
+        honoring NO_PROXY) - pass None to always connect directly. The option
+        requires websockets >= 15.0.
         """
         if ssl_context is not None and not address.lower().startswith("wss://"):
             raise ValueError("ssl_context option is only applicable to wss:// addresses")
+
+        if proxy is not True and not _websockets_supports_proxy():
+            raise ValueError(
+                "proxy option requires websockets >= 15.0, "
+                f"installed version is {websockets.__version__}"
+            )
 
         self.state: ClientState = ClientState.DISCONNECTED
         self.events: ClientEventHandler = events or ClientEventHandler()
@@ -207,6 +237,7 @@ class Client:
         self._reconnect_timer = None
         self._headers = headers or {}
         self._ssl_context = ssl_context
+        self._proxy = proxy
         self._server_subs: Dict[str, _ServerSubscription] = {}
         # Channel compaction: numeric channel ID -> subscription, used to route
         # pushes that carry an ID instead of the string channel name. IDs are
@@ -387,6 +418,11 @@ class Client:
                 # ssl=None as "no TLS" and raises ValueError for it on a wss://
                 # address, instead of falling back to the default TLS context.
                 connect_kwargs["ssl"] = self._ssl_context
+            if self._proxy is not True:
+                # Only pass proxy when configured: True is the websockets default
+                # (take proxy from the environment) and websockets < 15.0 does not
+                # accept the argument at all.
+                connect_kwargs["proxy"] = self._proxy
 
             try:
                 self._conn = await websockets.connect(

--- a/centrifuge/client.py
+++ b/centrifuge/client.py
@@ -1,6 +1,7 @@
 import asyncio
 import base64
 import contextlib
+import importlib.util
 import logging
 import ssl
 from asyncio import TimerHandle
@@ -111,6 +112,65 @@ def _websockets_supports_proxy() -> bool:
     return (major, minor) >= _PROXY_MIN_WEBSOCKETS_VERSION
 
 
+def _python_socks_installed() -> bool:
+    return importlib.util.find_spec("python_socks") is not None
+
+
+def _redact_proxy(proxy: str) -> str:
+    """Strip credentials from a proxy URL, so that it's safe to put in an error message."""
+    scheme, separator, rest = proxy.partition("://")
+    if not separator:
+        # Malformed URL without a scheme - it may still carry credentials.
+        scheme, rest = "", proxy
+    _, at, hostinfo = rest.rpartition("@")
+    if not at:
+        return proxy
+    return f"{scheme}{separator}***@{hostinfo}"
+
+
+def _validate_proxy(proxy: Union[str, Literal[True], None]) -> None:
+    """Validate the proxy option in the constructor, raising ValueError if it can't work.
+
+    Proxy misconfiguration is checked upfront because errors raised in the middle
+    of connecting are easy to miss: from the automatic reconnect task they end up
+    as an unretrieved task exception, and those which are neither OSError nor
+    WebSocketException (like the ImportError raised for a SOCKS proxy without
+    python-socks installed) are not even reported to the on_error handler.
+    """
+    if proxy is True or proxy is None:
+        # True is the websockets default (take the proxy from the environment) and
+        # None means connecting directly - which is what websockets < 15.0 does
+        # anyway, so neither needs a recent websockets nor further validation.
+        return
+
+    if not isinstance(proxy, str):
+        raise ValueError(f"proxy must be a proxy URL, None or True, got {proxy!r}")
+
+    if not _websockets_supports_proxy():
+        raise ValueError(
+            "proxy URL requires websockets >= 15.0, "
+            f"installed version is {websockets.__version__}"
+        )
+
+    try:
+        # Only available since websockets 15.0, hence the local import.
+        from websockets.uri import parse_proxy  # noqa: PLC0415
+    except ImportError:  # pragma: no cover - in case websockets moves the helper.
+        return
+
+    try:
+        parsed = parse_proxy(proxy)
+    except exceptions.InvalidProxy as e:
+        # Not str(e) - it embeds the proxy URL as is, together with the
+        # credentials it may contain, into a message which likely gets logged.
+        raise ValueError(f"{_redact_proxy(proxy)} isn't a valid proxy: {e.msg}") from e
+
+    if parsed.scheme.startswith("socks") and not _python_socks_installed():
+        raise ValueError(
+            f"{parsed.scheme} proxy requires the python-socks package to be installed"
+        )
+
+
 class ClientState(Enum):
     """ClientState represents possible states of Client connection."""
 
@@ -189,19 +249,17 @@ class Client:
 
         proxy sets the proxy to connect through, in the form
         "http://user:pass@host:port" ("socks5://..." also works, but requires the
-        python-socks package to be installed). By default proxy configuration is
-        taken from the environment (WS_PROXY/WSS_PROXY, HTTP_PROXY/HTTPS_PROXY,
-        honoring NO_PROXY) - pass None to always connect directly. The option
-        requires websockets >= 15.0.
+        python-socks package to be installed). Setting a proxy URL requires
+        websockets >= 15.0. By default (proxy=True) proxy configuration is taken
+        from the environment (WS_PROXY/WSS_PROXY, HTTP_PROXY/HTTPS_PROXY, honoring
+        NO_PROXY) - note that websockets < 15.0 has no proxy support at all and
+        always connects directly. Pass None to always connect directly, ignoring
+        the environment configuration.
         """
         if ssl_context is not None and not address.lower().startswith("wss://"):
             raise ValueError("ssl_context option is only applicable to wss:// addresses")
 
-        if proxy is not True and not _websockets_supports_proxy():
-            raise ValueError(
-                "proxy option requires websockets >= 15.0, "
-                f"installed version is {websockets.__version__}"
-            )
+        _validate_proxy(proxy)
 
         self.state: ClientState = ClientState.DISCONNECTED
         self.events: ClientEventHandler = events or ClientEventHandler()
@@ -431,7 +489,11 @@ class Client:
                     additional_headers=self._headers,
                     **connect_kwargs,
                 )
-            except (OSError, exceptions.WebSocketException) as e:
+            except (OSError, exceptions.WebSocketException, ImportError) as e:
+                # ImportError is what websockets raises for a SOCKS proxy without
+                # python-socks installed. An explicitly configured proxy is checked
+                # in the constructor, but a proxy coming from the environment can
+                # only fail here - and it must not escape into the reconnect task.
                 handler = self.events.on_error
                 await handler(
                     ErrorContext(code=_code_number(_ErrorCode.TRANSPORT_CLOSED), error=e)

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -21,12 +21,14 @@ requires_proxy_support = unittest.skipUnless(
 )
 
 
-async def _pipe(reader, writer):
+async def _pipe(reader, writer, recorder=None):
     try:
         while True:
             data = await reader.read(65536)
             if not data:
                 break
+            if recorder is not None:
+                recorder.append(data)
             writer.write(data)
             await writer.drain()
     except (ConnectionError, asyncio.IncompleteReadError):
@@ -47,6 +49,8 @@ class ConnectProxy:
         self.connect_targets = []
         # Proxy-Authorization header values received, in order.
         self.auth_headers = []
+        # Everything the client sent through the established tunnel.
+        self.tunneled = []
 
     async def start(self):
         self._server = await asyncio.start_server(self._handle, "127.0.0.1", 0)
@@ -116,7 +120,7 @@ class ConnectProxy:
         writer.write(b"HTTP/1.1 200 Connection established\r\n\r\n")
         await writer.drain()
         await asyncio.gather(
-            _pipe(reader, remote_writer),
+            _pipe(reader, remote_writer, recorder=self.tunneled),
             _pipe(remote_reader, writer),
             return_exceptions=True,
         )
@@ -209,11 +213,110 @@ class TestHTTPProxyAuth(TestProxyBase):
         self.assertEqual(self.proxy.auth_headers, [f"Basic {expected}"])
         await client.disconnect()
 
+    async def test_credentials_not_forwarded_to_server(self):
+        # Proxy credentials must only be sent to the proxy itself, never to the
+        # Centrifugo server behind it.
+        client = Client(self.server.url, use_protobuf=True, proxy=self.proxy.url)
+        await client.connect()
+        await client.ready(timeout=5)
+        await client.disconnect()
+        tunneled = b"".join(self.proxy.tunneled).lower()
+        self.assertNotIn(b"proxy-authorization", tunneled)
+        self.assertNotIn(base64.b64encode(b"user:pass").lower(), tunneled)
+        self.assertNotIn(b"user:pass", tunneled)
 
-class TestProxyVersionGuard(unittest.IsolatedAsyncioTestCase):
-    async def test_proxy_requires_recent_websockets(self):
+
+class TestProxyValidation(unittest.IsolatedAsyncioTestCase):
+    """Proxy misconfiguration must be reported by the constructor.
+
+    Otherwise it only surfaces in the middle of connecting, where it is either
+    swallowed as an unretrieved exception of the reconnect task, or reported to
+    on_error and retried forever - even though it can never start working.
+    """
+
+    address = "ws://localhost:8000/connection/websocket"
+
+    async def test_proxy_url_requires_recent_websockets(self):
         with mock.patch("centrifuge.client._websockets_supports_proxy", return_value=False):
             with self.assertRaises(ValueError):  # noqa: PT027
-                Client("ws://localhost:8000/connection/websocket", proxy="http://localhost:3128")
+                Client(self.address, proxy="http://localhost:3128")
             # The default (proxy from environment) keeps working on old websockets.
-            Client("ws://localhost:8000/connection/websocket")
+            Client(self.address)
+            # So does connecting directly - which is all old websockets ever does.
+            Client(self.address, proxy=None)
+
+    @requires_proxy_support
+    async def test_invalid_proxy_url_raises(self):
+        for proxy in (
+            "bogus://localhost:3128",  # Unsupported scheme.
+            "http://localhost:3128/path",  # Meaningless path.
+            "http://user@localhost:3128",  # Username without password.
+        ):
+            with self.subTest(proxy=proxy), self.assertRaises(ValueError):  # noqa: PT027
+                Client(self.address, proxy=proxy)
+
+    @requires_proxy_support
+    async def test_non_string_proxy_raises(self):
+        # False is a natural way to spell "no proxy" - websockets would only
+        # reject it while connecting, with a message about an empty scheme.
+        with self.assertRaises(ValueError):  # noqa: PT027
+            Client(self.address, proxy=False)
+
+    @requires_proxy_support
+    async def test_socks_proxy_without_python_socks_raises(self):
+        with mock.patch("centrifuge.client._python_socks_installed", return_value=False):
+            with self.assertRaises(ValueError):  # noqa: PT027
+                Client(self.address, proxy="socks5://localhost:1080")
+            # An HTTP proxy does not need python-socks.
+            Client(self.address, proxy="http://localhost:3128")
+
+    @requires_proxy_support
+    async def test_socks_proxy_accepted_with_python_socks(self):
+        with mock.patch("centrifuge.client._python_socks_installed", return_value=True):
+            Client(self.address, proxy="socks5://localhost:1080")
+
+    @requires_proxy_support
+    async def test_validation_error_does_not_leak_credentials(self):
+        # Constructor errors end up in logs and error trackers, so the proxy URL
+        # must not be echoed back with its credentials in place.
+        with self.assertRaises(ValueError) as raised:  # noqa: PT027
+            Client(self.address, proxy="bogus://user:s3cret@localhost:3128")
+        message = str(raised.exception)
+        self.assertNotIn("s3cret", message)
+        self.assertNotIn("user", message)
+        self.assertIn("***@localhost:3128", message)
+
+
+@requires_proxy_support
+@unittest.skipIf(
+    centrifuge.client._python_socks_installed(),
+    "test needs python-socks to be absent to trigger the ImportError",
+)
+class TestSocksProxyFromEnvironment(unittest.IsolatedAsyncioTestCase):
+    async def test_missing_python_socks_reported_as_error(self):
+        # A proxy taken from the environment can not be validated in the
+        # constructor: websockets raises ImportError for it while connecting,
+        # which is neither OSError nor WebSocketException - so without explicit
+        # handling it would escape _create_connection instead of reaching
+        # on_error, leaving the client stuck in the connecting state.
+        error = asyncio.Future()
+
+        async def on_error(ctx):
+            if not error.done():
+                error.set_result(ctx)
+
+        env = {"ws_proxy": "socks5://127.0.0.1:1080", "no_proxy": ""}
+        with mock.patch.dict(os.environ, env, clear=False):
+            client = Client(
+                "ws://localhost:8000/connection/websocket",
+                use_protobuf=True,
+                # Keep the retry far away so a single attempt is observed.
+                min_reconnect_delay=30,
+                max_reconnect_delay=30,
+            )
+            client.events.on_error = on_error
+            await client.connect()
+            ctx = await asyncio.wait_for(error, timeout=5)
+            self.assertIsInstance(ctx.error, ImportError)
+            self.assertEqual(client.state, ClientState.CONNECTING)
+            await client.disconnect()

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -1,7 +1,11 @@
 import asyncio
 import base64
 import contextlib
+import logging
 import os
+import shutil
+import ssl
+import tempfile
 import unittest
 from unittest import mock
 
@@ -10,6 +14,7 @@ import websockets
 import centrifuge.client
 from centrifuge import Client, ClientState
 from tests.fake_server import FakeCentrifugoServer
+from tests.test_ssl import _generate_cert
 
 # Tests for the proxy option (https://github.com/centrifugal/centrifuge-python/issues/45),
 # exercised against a minimal in-process HTTP proxy (CONNECT method) in front of
@@ -224,6 +229,77 @@ class TestHTTPProxyAuth(TestProxyBase):
         self.assertNotIn(b"proxy-authorization", tunneled)
         self.assertNotIn(base64.b64encode(b"user:pass").lower(), tunneled)
         self.assertNotIn(b"user:pass", tunneled)
+
+
+@requires_proxy_support
+@unittest.skipUnless(shutil.which("openssl"), "openssl is required to generate a test cert")
+class TestProxyWithTLS(unittest.IsolatedAsyncioTestCase):
+    """A proxy must not weaken TLS: the tunnel stays end to end encrypted."""
+
+    async def asyncSetUp(self):
+        self._tmpdir = tempfile.TemporaryDirectory()
+        self.cert_path, key_path = _generate_cert(self._tmpdir.name)
+        server_ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+        server_ctx.load_cert_chain(self.cert_path, key_path)
+        self.server = FakeCentrifugoServer()
+        await self.server.start(ssl_context=server_ctx)
+        self.proxy = ConnectProxy()
+        await self.proxy.start()
+
+    async def asyncTearDown(self):
+        await self.proxy.stop()
+        await self.server.stop()
+        self._tmpdir.cleanup()
+
+    async def test_wss_through_proxy_is_opaque_to_proxy(self):
+        client_ctx = ssl.create_default_context(cafile=str(self.cert_path))
+        client = Client(
+            self.server.url, use_protobuf=True, ssl_context=client_ctx, proxy=self.proxy.url
+        )
+        await client.connect()
+        await client.ready(timeout=5)
+        self.assertEqual(client.state, ClientState.CONNECTED)
+        self.assertEqual(self.proxy.connect_targets, [f"localhost:{self.server.port}"])
+        await client.disconnect()
+
+        # Beyond the CONNECT request the proxy only relays TLS records (the first
+        # byte of a TLS handshake record is 0x16) - the WebSocket handshake and
+        # the connection token inside it are not visible to it.
+        tunneled = b"".join(self.proxy.tunneled)
+        self.assertTrue(tunneled.startswith(b"\x16"))
+        self.assertNotIn(b"Sec-WebSocket-Key", tunneled)
+
+    async def test_certificate_still_verified_through_proxy(self):
+        # Tunneling must not silently skip verification of the server
+        # certificate: without a matching CA the self-signed certificate of the
+        # test server is rejected, exactly like on a direct connection.
+        # The aborted TLS handshake makes asyncio log a server-side traceback.
+        asyncio_logger = logging.getLogger("asyncio")
+        previous_level = asyncio_logger.level
+        asyncio_logger.setLevel(logging.CRITICAL)
+        self.addCleanup(asyncio_logger.setLevel, previous_level)
+
+        error = asyncio.Future()
+
+        async def on_error(ctx):
+            if not error.done():
+                error.set_result(ctx)
+
+        client = Client(
+            self.server.url,
+            use_protobuf=True,
+            proxy=self.proxy.url,
+            # Keep the retry far away so a single attempt is observed.
+            min_reconnect_delay=30,
+            max_reconnect_delay=30,
+        )
+        client.events.on_error = on_error
+        await client.connect()
+        ctx = await asyncio.wait_for(error, timeout=5)
+        self.assertIsInstance(ctx.error, ssl.SSLCertVerificationError)
+        self.assertEqual(client.state, ClientState.CONNECTING)
+        self.assertEqual(self.proxy.connect_targets, [f"localhost:{self.server.port}"])
+        await client.disconnect()
 
 
 class TestProxyValidation(unittest.IsolatedAsyncioTestCase):

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -1,0 +1,219 @@
+import asyncio
+import base64
+import contextlib
+import os
+import unittest
+from unittest import mock
+
+import websockets
+
+import centrifuge.client
+from centrifuge import Client, ClientState
+from tests.fake_server import FakeCentrifugoServer
+
+# Tests for the proxy option (https://github.com/centrifugal/centrifuge-python/issues/45),
+# exercised against a minimal in-process HTTP proxy (CONNECT method) in front of
+# the FakeCentrifugoServer.
+
+requires_proxy_support = unittest.skipUnless(
+    centrifuge.client._websockets_supports_proxy(),
+    f"proxy requires websockets >= 15.0, installed {websockets.__version__}",
+)
+
+
+async def _pipe(reader, writer):
+    try:
+        while True:
+            data = await reader.read(65536)
+            if not data:
+                break
+            writer.write(data)
+            await writer.drain()
+    except (ConnectionError, asyncio.IncompleteReadError):
+        pass
+    finally:
+        with contextlib.suppress(ConnectionError):
+            writer.close()
+
+
+class ConnectProxy:
+    """Minimal HTTP proxy supporting the CONNECT method, for tests."""
+
+    def __init__(self, username="", password=""):
+        self._server = None
+        self.port = 0
+        self._credentials = (username, password) if username else None
+        # CONNECT targets ("host:port") received, in order.
+        self.connect_targets = []
+        # Proxy-Authorization header values received, in order.
+        self.auth_headers = []
+
+    async def start(self):
+        self._server = await asyncio.start_server(self._handle, "127.0.0.1", 0)
+        self.port = self._server.sockets[0].getsockname()[1]
+
+    async def stop(self):
+        if self._server:
+            self._server.close()
+            await self._server.wait_closed()
+
+    @property
+    def url(self):
+        if self._credentials:
+            username, password = self._credentials
+            return f"http://{username}:{password}@127.0.0.1:{self.port}"
+        return f"http://127.0.0.1:{self.port}"
+
+    def _authorized(self, headers):
+        if not self._credentials:
+            return True
+        username, password = self._credentials
+        expected = base64.b64encode(f"{username}:{password}".encode()).decode()
+        return headers.get("proxy-authorization") == f"Basic {expected}"
+
+    async def _handle(self, reader, writer):
+        try:
+            request = await reader.readuntil(b"\r\n\r\n")
+        except (asyncio.IncompleteReadError, ConnectionError):
+            writer.close()
+            return
+
+        lines = request.decode().split("\r\n")
+        method, _, target = lines[0].partition(" ")
+        target = target.split(" ")[0]
+        headers = {}
+        for line in lines[1:]:
+            name, sep, value = line.partition(":")
+            if sep:
+                headers[name.strip().lower()] = value.strip()
+
+        if method == "CONNECT":
+            self.connect_targets.append(target)
+        if "proxy-authorization" in headers:
+            self.auth_headers.append(headers["proxy-authorization"])
+
+        if method != "CONNECT":
+            writer.write(b"HTTP/1.1 405 Method Not Allowed\r\n\r\n")
+            await writer.drain()
+            writer.close()
+            return
+
+        if not self._authorized(headers):
+            writer.write(b"HTTP/1.1 407 Proxy Authentication Required\r\n\r\n")
+            await writer.drain()
+            writer.close()
+            return
+
+        host, _, port = target.rpartition(":")
+        try:
+            remote_reader, remote_writer = await asyncio.open_connection(host, int(port))
+        except OSError:
+            writer.write(b"HTTP/1.1 502 Bad Gateway\r\n\r\n")
+            await writer.drain()
+            writer.close()
+            return
+
+        writer.write(b"HTTP/1.1 200 Connection established\r\n\r\n")
+        await writer.drain()
+        await asyncio.gather(
+            _pipe(reader, remote_writer),
+            _pipe(remote_reader, writer),
+            return_exceptions=True,
+        )
+
+
+class TestProxyBase(unittest.IsolatedAsyncioTestCase):
+    proxy_username = ""
+    proxy_password = ""
+
+    async def asyncSetUp(self):
+        self.server = FakeCentrifugoServer()
+        await self.server.start()
+        self.proxy = ConnectProxy(self.proxy_username, self.proxy_password)
+        await self.proxy.start()
+
+    async def asyncTearDown(self):
+        await self.proxy.stop()
+        await self.server.stop()
+
+    def target(self):
+        return f"localhost:{self.server.port}"
+
+
+@requires_proxy_support
+class TestHTTPProxy(TestProxyBase):
+    async def test_connects_through_proxy(self):
+        client = Client(self.server.url, use_protobuf=True, proxy=self.proxy.url)
+        await client.connect()
+        await client.ready(timeout=5)
+        self.assertEqual(client.state, ClientState.CONNECTED)
+        self.assertEqual(self.proxy.connect_targets, [self.target()])
+        await client.disconnect()
+
+    async def test_proxy_from_environment_used_by_default(self):
+        # Without an explicit option websockets takes the proxy from the
+        # environment - the SDK must not interfere with that.
+        env = {"ws_proxy": self.proxy.url, "no_proxy": ""}
+        with mock.patch.dict(os.environ, env, clear=False):
+            client = Client(self.server.url, use_protobuf=True)
+            await client.connect()
+            await client.ready(timeout=5)
+            self.assertEqual(client.state, ClientState.CONNECTED)
+            self.assertEqual(self.proxy.connect_targets, [self.target()])
+            await client.disconnect()
+
+    async def test_proxy_none_ignores_environment(self):
+        env = {"ws_proxy": self.proxy.url, "no_proxy": ""}
+        with mock.patch.dict(os.environ, env, clear=False):
+            client = Client(self.server.url, use_protobuf=True, proxy=None)
+            await client.connect()
+            await client.ready(timeout=5)
+            self.assertEqual(client.state, ClientState.CONNECTED)
+            self.assertEqual(self.proxy.connect_targets, [])
+            await client.disconnect()
+
+    async def test_unreachable_proxy_reported_as_error(self):
+        error = asyncio.Future()
+
+        async def on_error(ctx):
+            if not error.done():
+                error.set_result(ctx)
+
+        # Port 1 is reserved and nothing listens on it.
+        client = Client(
+            self.server.url,
+            use_protobuf=True,
+            proxy="http://127.0.0.1:1",
+            min_reconnect_delay=30,
+            max_reconnect_delay=30,
+        )
+        client.events.on_error = on_error
+        await client.connect()
+        await asyncio.wait_for(error, timeout=5)
+        self.assertEqual(client.state, ClientState.CONNECTING)
+        await client.disconnect()
+
+
+@requires_proxy_support
+class TestHTTPProxyAuth(TestProxyBase):
+    proxy_username = "user"
+    proxy_password = "pass"  # noqa: S105 - test credentials.
+
+    async def test_credentials_from_proxy_url_sent(self):
+        client = Client(self.server.url, use_protobuf=True, proxy=self.proxy.url)
+        await client.connect()
+        await client.ready(timeout=5)
+        self.assertEqual(client.state, ClientState.CONNECTED)
+        self.assertEqual(self.proxy.connect_targets, [self.target()])
+        expected = base64.b64encode(b"user:pass").decode()
+        self.assertEqual(self.proxy.auth_headers, [f"Basic {expected}"])
+        await client.disconnect()
+
+
+class TestProxyVersionGuard(unittest.IsolatedAsyncioTestCase):
+    async def test_proxy_requires_recent_websockets(self):
+        with mock.patch("centrifuge.client._websockets_supports_proxy", return_value=False):
+            with self.assertRaises(ValueError):  # noqa: PT027
+                Client("ws://localhost:8000/connection/websocket", proxy="http://localhost:3128")
+            # The default (proxy from environment) keeps working on old websockets.
+            Client("ws://localhost:8000/connection/websocket")


### PR DESCRIPTION
Closes #45

Adds `proxy` option to `Client` constructor – the value is passed to `websockets.connect`:

```python
client = Client(
    "ws://localhost:8000/connection/websocket",
    proxy="http://user:pass@proxy-host:3128",
)
```

Semantics follow websockets:

* default `proxy=True` – proxy configuration is taken from the environment (`WS_PROXY`/`WSS_PROXY`, `HTTP_PROXY`/`HTTPS_PROXY`, honoring `NO_PROXY`), exactly as it works now
* `proxy="scheme://..."` – connect through the given proxy
* `proxy=None` – always connect directly, ignoring the environment

SOCKS proxies (`socks5://...`) work too, but require `python-socks` to be installed – documented in README.

### Note on websockets versions

The `proxy` argument of `websockets.connect` only exists since **websockets 15.0**, while the SDK still supports 14.x, where it ends up in `**kwargs` and surfaces as a confusing `TypeError: create_connection() got an unexpected keyword argument 'proxy'` from deep inside websockets on every connect attempt.

So the option is passed to `websockets.connect` only when explicitly configured (the default is not passed at all, keeping 14.x working), and configuring it on an older websockets raises a clear `ValueError` from the `Client` constructor. If the minimum supported websockets is bumped to 15.0 at some point, `_websockets_supports_proxy` and the check can simply be dropped.

### Tests

`tests/test_proxy.py` runs a minimal in-process HTTP proxy (CONNECT method) in front of the fake Centrifugo server and covers:

* connecting through a proxy (the proxy really sees `CONNECT localhost:<port>`)
* credentials from the proxy URL (`Proxy-Authorization: Basic ...`)
* proxy taken from the environment when the option is not set
* `proxy=None` ignoring the environment configuration
* unreachable proxy reported via `on_error` instead of raising
* the websockets version guard

Proxy tests are skipped automatically on websockets < 15.0. Full suite passes on websockets 14.2 and 15.0.
