### PR TITLE
Fail fast when test Centrifugo is not running

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,47 @@
+# centrifuge-python
+
+Python asyncio WebSocket SDK for Centrifugo / Centrifuge-based servers.
+
+## Environment
+
+The project uses a virtualenv at `.venv` in the repo root. Activate it, or call
+its interpreter directly:
+
+```bash
+. .venv/bin/activate     # or use .venv/bin/python explicitly
+make dev                 # pip install -e ".[dev]" + pre-commit install
+```
+
+Do not install into the system Python.
+
+## Tests
+
+Most of `tests/test_client.py` runs against a real Centrifugo — the one from
+`docker-compose.yml`, configured with the channel namespaces and options those
+tests expect. Start it before running the suite:
+
+```bash
+docker compose up -d
+make test                # python -m unittest discover -s tests
+```
+
+`tests/test_client.py` calls `require_centrifugo()` (see `tests/centrifugo.py`)
+in `setUpModule`: if nothing answers on `localhost:8000` within 5 seconds, the
+module errors out with a message instead of hanging. The hang is what happens
+otherwise — the SDK reconnects forever, so tests awaiting publications never
+return. The check only proves something is listening: a Centrifugo of another
+project on port 8000 passes it and then hangs the recovery tests, which need
+this compose file's channel options.
+
+The remaining suites (`test_filter`, `test_fossil`, `test_proxy`, `test_ssl`,
+`test_state_invalidation`, `test_sub_refresh`, `test_background_tasks`) use the
+in-process `tests/fake_server.py` or no server at all, and run without Docker.
+
+## Lint
+
+```bash
+make lint                # ruff check .
+make lint-fix            # ruff check . --fix
+```
+
+Ruff config lives in `pyproject.toml`; `pre-commit` runs it on commit.

--- a/tests/centrifugo.py
+++ b/tests/centrifugo.py
@@ -1,0 +1,52 @@
+"""Preflight check for the Centrifugo server the integration tests run against.
+
+Some suites talk to the real server from docker-compose.yml. The SDK reconnects
+forever by design and those tests await publications without a deadline, so a
+missing server does not make them fail - it makes them hang. Checking up front
+turns "Centrifugo is not up" into an immediate, explanatory error instead.
+"""
+
+import time
+import urllib.error
+import urllib.request
+
+CENTRIFUGO_HTTP_URL = "http://localhost:8000"
+# How long to wait for the server on start: enough for a container which is
+# still coming up, short enough to not look like a hang.
+STARTUP_TIMEOUT = 5.0
+
+
+def _responds():
+    """True if something at the address answers HTTP - i.e. Centrifugo is up.
+
+    Any status code counts: the URL is the WebSocket endpoint, so a plain GET is
+    answered with an error, which is still proof the server is serving. A bare
+    TCP connect is not enough - while a container starts, Docker's port
+    forwarder already accepts connections and then resets them.
+    """
+    try:
+        urllib.request.urlopen(  # noqa: S310 - constant http:// URL.
+            CENTRIFUGO_HTTP_URL + "/connection/websocket", timeout=1
+        )
+    except urllib.error.HTTPError:
+        return True
+    except OSError:
+        return False
+    return True
+
+
+def require_centrifugo(timeout=STARTUP_TIMEOUT):
+    """Wait up to timeout seconds for Centrifugo, raise RuntimeError if absent.
+
+    Call from setUpModule(): unittest reports the error against every test of
+    the module, so the suite fails fast with a message saying what to start.
+    """
+    deadline = time.monotonic() + timeout
+    while not _responds():
+        if time.monotonic() >= deadline:
+            raise RuntimeError(
+                f"Centrifugo did not respond at {CENTRIFUGO_HTTP_URL} within "
+                f"{timeout:.0f}s. These tests need the server from this repo's "
+                f"docker-compose.yml - start it with `docker compose up -d`."
+            )
+        time.sleep(0.1)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -35,6 +35,7 @@ from websockets.protocol import State
 
 import centrifuge.protocol.client_pb2 as protocol_pb2
 
+from tests.centrifugo import require_centrifugo
 from tests.fake_server import FakeCentrifugoServer
 
 logging.basicConfig(
@@ -43,6 +44,13 @@ logging.basicConfig(
 )
 cf_logger = logging.getLogger("centrifuge")
 cf_logger.setLevel(logging.DEBUG)
+
+
+def setUpModule():
+    # Most tests here talk to the Centrifugo from docker-compose.yml and wait
+    # on futures without a timeout, so a missing server means a hang. Fail here
+    # instead, with a message saying what to start.
+    require_centrifugo()
 
 
 def base64url_encode(data):


### PR DESCRIPTION
`tests/test_client.py` runs against the Centrifugo from `docker-compose.yml`. It awaits publications without a deadline while the SDK reconnects forever, so with no server running the suite did not fail — it hung indefinitely.

- `tests/centrifugo.py` (new): `require_centrifugo()` waits up to 5 seconds for an HTTP answer on `localhost:8000`, then raises with a message saying to run `docker compose up -d`. Any HTTP status counts as up — a plain GET to the WebSocket endpoint is answered with an error, which still proves the server is serving; a bare TCP connect is not enough, since Docker's port forwarder accepts connections while the container is still starting.
- `tests/test_client.py`: calls it from `setUpModule()`, so unittest reports one error for the module and the run ends in ~5s instead of hanging. It is the only suite needing the real server — the others use `tests/fake_server.py` or no server at all.
- `CLAUDE.md` (new): notes the `.venv` environment, that tests need `docker compose up -d`, which suites run without Docker, and the lint commands.

Checked: full suite `Ran 100 tests ... OK` with the server up; pointed at a dead port the module errors after 5.1s with 0 tests run. `ruff check .` clean.