### PR TITLE
Remove unused backoff factor/jitter class attributes

### DIFF
--- a/centrifuge/client.py
+++ b/centrifuge/client.py
@@ -205,9 +205,6 @@ class DeltaType(Enum):
 class Client:
     """Client is a websocket client to Centrifuge/Centrifugo server."""
 
-    _reconnect_backoff_factor = 2
-    _reconnect_backoff_jitter = 0.5
-
     def __init__(
         self,
         address: str,
@@ -1766,9 +1763,6 @@ class Subscription:
     See more details about subscription behaviour in
     https://centrifugal.dev/docs/transports/client_api.
     """
-
-    _resubscribe_backoff_factor = 2
-    _resubscribe_backoff_jitter = 0.5
 
     def __init__(self) -> None:
         # Some definitions required to make PyCharm linting happy.


### PR DESCRIPTION
## Summary

`Client._reconnect_backoff_factor` / `_reconnect_backoff_jitter` and
`Subscription._resubscribe_backoff_factor` / `_resubscribe_backoff_jitter`
are dead code: leftovers from a previous backoff implementation. The
actual reconnect/resubscribe delay is computed by `utils._backoff()`,
which takes `min_value`/`max_value` and full-jitter, and does not
reference these attributes at all. They're private, unused anywhere
else in the codebase, and not mentioned in tests or docs.

This is a pure dead-code removal; no behavior change.

## Test plan

- `make lint` — passes
- `python -m unittest discover -s tests` against the real Centrifugo from
  `docker-compose.yml` (all 100 tests, including reconnect/resubscribe
  paths) — passes