### PR TITLE
Fix wrong error code and dead retry in sub_refresh token-fetch failure

### DIFF
--- a/centrifuge/client.py
+++ b/centrifuge/client.py
@@ -882,11 +882,10 @@ class Client:
             handler = sub.events.on_error
             await handler(
                 SubscriptionErrorContext(
-                    code=_code_number(_ErrorCode.SUBSCRIPTION_SUBSCRIBE_TOKEN),
+                    code=_code_number(_ErrorCode.SUBSCRIPTION_REFRESH_TOKEN),
                     error=e,
                 ),
             )
-            self._spawn(sub._schedule_resubscribe())
             return
 
         cmd_id = self._next_command_id()

--- a/tests/test_sub_refresh.py
+++ b/tests/test_sub_refresh.py
@@ -1,7 +1,7 @@
 import asyncio
 import unittest
 
-from centrifuge import Client
+from centrifuge import Client, codes
 from tests.fake_server import FakeCentrifugoServer
 
 import centrifuge.protocol.client_pb2 as protocol
@@ -55,6 +55,50 @@ class TestSubRefreshWire(unittest.IsolatedAsyncioTestCase):
         req = await asyncio.wait_for(sub_refresh_cmd, timeout=5)
         self.assertEqual(req.channel, "restaurant:42:in")
         self.assertEqual(req.token, "refreshed-sub-token")
+
+        await client.disconnect()
+
+
+class TestSubRefreshTokenFetchError(unittest.IsolatedAsyncioTestCase):
+    async def asyncSetUp(self):
+        self.server = FakeCentrifugoServer()
+        await self.server.start()
+
+    async def asyncTearDown(self):
+        await self.server.stop()
+
+    async def test_get_token_error_reports_refresh_code(self):
+        # A failure to obtain a fresh token during a scheduled sub_refresh must
+        # be reported with SUBSCRIPTION_REFRESH_TOKEN, matching the other error
+        # paths in this same refresh flow (timeout / reply error below).
+        self.server.on_subscribe = lambda _ch, _req: protocol.SubscribeResult(expires=True, ttl=1)
+
+        calls = 0
+
+        async def get_token(_channel):
+            nonlocal calls
+            calls += 1
+            if calls == 1:
+                return "initial-sub-token"
+            raise RuntimeError("token service unavailable")
+
+        client = Client(self.server.url, use_protobuf=True)
+        sub = client.new_subscription("restaurant:42:in", get_token=get_token)
+
+        error_ctx = asyncio.Future()
+
+        async def on_error(ctx):
+            if not error_ctx.done():
+                error_ctx.set_result(ctx)
+
+        sub.events.on_error = on_error
+
+        await client.connect()
+        await sub.subscribe()
+
+        ctx = await asyncio.wait_for(error_ctx, timeout=5)
+        self.assertEqual(ctx.code, codes._ErrorCode.SUBSCRIPTION_REFRESH_TOKEN.value)
+        self.assertIsInstance(ctx.error, RuntimeError)
 
         await client.disconnect()
 


### PR DESCRIPTION
## Summary

`Client._sub_refresh()` has three error paths that report failures via `sub.events.on_error`. Two of them (a timed-out reply, and a reply carrying a server error) correctly use `SUBSCRIPTION_REFRESH_TOKEN`. The third - `get_token()` raising while fetching a fresh token for the refresh - incorrectly used `SUBSCRIPTION_SUBSCRIBE_TOKEN`, apparently copy-pasted from the analogous block in `_subscribe()`. Applications branching on `ctx.code` in `on_error` would misclassify a refresh-token failure as a subscribe-token failure.

That same branch also called `self._spawn(sub._schedule_resubscribe())` afterwards. `_sub_refresh()` is only ever invoked from `Subscription._refresh()`, which only calls it while `self.state == SubscriptionState.SUBSCRIBED`. `_schedule_resubscribe()` is a no-op unless the subscription is `SUBSCRIBING`, so that call never did anything in practice - it's removed, matching `Client._refresh()`'s handling of its own (connection-level) token-fetch errors, which just reports the error and returns.

No public API changes - only the reported `ErrorContext.code` value changes for this specific failure case, and a dead call is removed.

## Test plan

- Added `tests/test_sub_refresh.py::TestSubRefreshTokenFetchError`, which makes `get_token` raise on the refresh call and asserts `on_error` fires with `SUBSCRIPTION_REFRESH_TOKEN`. Verified it fails against the old code (`8 != 9`) and passes with the fix.
- `python -m unittest tests.test_filter tests.test_fossil tests.test_proxy tests.test_ssl tests.test_state_invalidation tests.test_sub_refresh tests.test_background_tasks` - all 40 non-Docker tests pass.
- `ruff check .` - passes.