### PR TITLE
Fix Client.ready() failing instantly while reconnecting

### DIFF
--- a/centrifuge/client.py
+++ b/centrifuge/client.py
@@ -1276,7 +1276,7 @@ class Client:
             raise ReplyError(error["code"], error["message"], error.get("temporary", False))
 
     def _check_state(self):
-        if self.state != ClientState.CONNECTED:
+        if self.state == ClientState.DISCONNECTED:
             raise ClientDisconnectedError("client disconnected")
 
     async def ready(self, timeout: Optional[float] = None) -> None:

--- a/tests/test_ready.py
+++ b/tests/test_ready.py
@@ -1,0 +1,42 @@
+import asyncio
+import unittest
+
+from centrifuge import Client
+from centrifuge.client import ClientState
+from centrifuge.exceptions import ClientDisconnectedError, OperationTimeoutError
+
+# ready() (and therefore publish/history/presence/rpc, which all call it first)
+# is meant to tolerate a client that is mid-reconnect: it should wait up to
+# `timeout` for `_connected_future` to resolve instead of failing instantly.
+# _check_state() used to raise whenever state != CONNECTED, which included
+# CONNECTING - the exact state a transient reconnect is in - defeating the
+# wait/timeout mechanism entirely.
+
+
+class TestClientReady(unittest.IsolatedAsyncioTestCase):
+    def setUp(self):
+        self.client = Client("ws://localhost:8000/connection/websocket")
+
+    async def test_ready_waits_while_connecting(self):
+        self.client.state = ClientState.CONNECTING
+        task = asyncio.ensure_future(self.client.ready(timeout=1))
+        await asyncio.sleep(0)
+        self.assertFalse(task.done())
+
+        self.client.state = ClientState.CONNECTED
+        self.client._connected_future.set_result(True)
+        await task  # does not raise
+
+    async def test_ready_times_out_while_connecting(self):
+        self.client.state = ClientState.CONNECTING
+        with self.assertRaises(OperationTimeoutError):  # noqa: PT027
+            await self.client.ready(timeout=0.05)
+
+    async def test_ready_raises_immediately_when_disconnected(self):
+        self.client.state = ClientState.DISCONNECTED
+        with self.assertRaises(ClientDisconnectedError):  # noqa: PT027
+            await self.client.ready(timeout=1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed

`Client._check_state()` raised `ClientDisconnectedError` whenever `state != ClientState.CONNECTED`, which includes `CONNECTING` — the state a client is in during an automatic reconnect. `ready()` calls `_check_state()` before waiting on `_connected_future`, so any call to `publish`/`history`/`presence`/`presence_stats`/`rpc` (all of which call `ready()` first) made while the SDK is mid-reconnect failed instantly with `ClientDisconnectedError`, instead of waiting up to the given `timeout` for the reconnect to complete as the method's `timeout` parameter and docstring in `exceptions.py` promise.

`Subscription._check_state()` already implements the correct pattern: it only raises on the terminal `UNSUBSCRIBED` state, not the transient `SUBSCRIBING` one, so `Subscription.ready()` genuinely waits through a resubscribe. This change mirrors that on the client side, only raising on the terminal `DISCONNECTED` state — matching `ClientDisconnectedError`'s own documented contract ("raised... when operations are attempted on a Client in DISCONNECTED state").

## Why

Any caller relying on `ready()`/`publish()`/etc. to ride out a transient reconnect (the documented purpose of the `timeout` parameter) would instead see spurious `ClientDisconnectedError`s during reconnects, even though the client recovers moments later.

## How verified

Added `tests/test_ready.py` with three cases exercising `Client.ready()` directly against internal state (no server needed, same pattern as `tests/test_background_tasks.py`):
- while `state == CONNECTING`, `ready()` waits rather than raising, and returns once `_connected_future` resolves
- while `state == CONNECTING`, `ready()` still respects its `timeout` and raises `OperationTimeoutError` if the future never resolves in time
- while `state == DISCONNECTED`, `ready()` still raises `ClientDisconnectedError` immediately (terminal state — unchanged behavior)

Confirmed the first two cases fail against the old code (immediate `ClientDisconnectedError` instead of waiting) and pass with the fix; the third passes unchanged in both. Kept the test in the tree since it guards a real regression class, doesn't duplicate existing coverage, and isn't tied to internals beyond what other in-process tests already touch.

Ran the full suite (`python -m unittest discover -s tests`, 104 tests, against this repo's own `docker-compose.yml` Centrifugo) and `make lint` — both pass.