### PR TITLE
Remove dead sentinel put in Client._do_disconnect

### DIFF
--- a/centrifuge/client.py
+++ b/centrifuge/client.py
@@ -1483,7 +1483,9 @@ class Client:
 
         transition_from_connected = self.state == ClientState.CONNECTED
 
-        await self._messages.put(None)
+        # _process_messages_task is already cancelled and awaited above, so nothing
+        # reads from this queue anymore - replace it (instead of just leaving it) to
+        # drop any messages received but not yet processed on the old connection.
         self._messages = asyncio.Queue()
 
         if not reconnect:


### PR DESCRIPTION
## Summary

`Client._do_disconnect()` does:

```python
if self._process_messages_task and not self._process_messages_task.done():
    self._process_messages_task.cancel()
    with contextlib.suppress(asyncio.CancelledError):
        await self._process_messages_task
...
await self._messages.put(None)
self._messages = asyncio.Queue()
```

`_process_messages()` treats `None` on the queue as a "stop" sentinel, but by the time `put(None)` runs, `_process_messages_task` has already been cancelled and awaited to completion a few lines above - `await task` only returns once the task is done, so there is no consumer left to ever read that sentinel. It's a leftover from before the task was cancelled directly, and now it's a no-op `put` on a queue about to be discarded anyway.

The queue swap right after it does matter: it drops any messages that were received on the old connection but not yet processed, so the next `_process_messages_task` (spawned fresh on reconnect) doesn't process stale bytes mixed with the new session. This change keeps that swap and drops the dead `put(None)`, with a comment explaining why the swap is there.

No behavior change - `self._messages` ends up a fresh, empty queue either way.

## Verification

- `make lint` - passes.
- `make test` (full suite, `docker compose up -d` with this repo's own Centrifugo) - all 112 tests pass, including the disconnect/reconnect paths in `test_client.py` that exercise this method.
- Also ran the no-Docker suites individually (`test_background_tasks`, `test_state_invalidation`, `test_sub_refresh`, `test_ready`, `test_filter`, `test_fossil`, `test_proxy`, `test_ssl`, `test_utils`) - all pass.

No new regression test added: this is a dead-code removal with no observable behavior change (confirmed by reading `_do_disconnect`'s control flow - `_process_messages_task` is unconditionally cancelled and awaited before the `put(None)` line), not a bug fix, so there's no failing-before/passing-after case to capture.