### PR TITLE
Remove dead sentinel handling in Client._process_messages

### DIFF
--- a/centrifuge/client.py
+++ b/centrifuge/client.py
@@ -1685,13 +1685,9 @@ class Client:
     async def _process_messages(self) -> None:
         logger.debug("start message processing routine")
         while True:
-            if self._messages:
-                message = await self._messages.get()
-                if message is None:
-                    break
-                logger.debug("start processing message: %s", message)
-                await self._process_incoming_data(message)
-        logger.debug("stop message processing routine")
+            message = await self._messages.get()
+            logger.debug("start processing message: %s", message)
+            await self._process_incoming_data(message)
 
     async def _listen(self) -> None:
         logger.debug("start reading connection")


### PR DESCRIPTION
## Summary

- `Client._process_messages` looped on `if self._messages:` and broke out on a `None` sentinel value read from the queue.
- `self._messages` is an `asyncio.Queue` instance, always truthy, so that condition was always true.
- No code ever puts `None` onto the queue: `#60` (6620fe3) removed the `await self._messages.put(None)` call in `_do_disconnect`, since `_process_messages_task` is stopped by direct cancellation, and that call was already a no-op by the time it ran (the task was already cancelled and awaited). That commit's message noted the `put()` was dead but left the corresponding sentinel-handling in the loop itself, which is what this PR removes.
- The loop now exits only via task cancellation (`CancelledError` propagating out of `await self._messages.get()`), matching how it's actually stopped everywhere it's used.

No behavior change - both removed conditions were unreachable/always-true.

## Test plan

- `ruff check .` - passes.
- Started this repo's own Centrifugo via `docker compose up -d --wait` (no other SDK's container was running on port 8000) and ran the full suite: `python -m unittest discover -s tests` - all 112 tests pass.
- Brought the container back down afterward (`docker compose down`).