### PR TITLE
Reset server-side subscription recovery position on state invalidation

### DIFF
--- a/centrifuge/client.py
+++ b/centrifuge/client.py
@@ -1455,6 +1455,14 @@ class Client:
         self._token = ""
         for sub in self._subs.values():
             sub._invalidate_state()
+        for server_sub in self._server_subs.values():
+            # Reset cached recovery position to a sentinel the server can never
+            # match, mirroring _invalidate_state() above for client-side subs.
+            # Without this, _construct_connect_command() would keep sending the
+            # stale pre-invalidation offset/epoch as recovery params on every
+            # reconnect, defeating state invalidation for server-side subs.
+            server_sub.offset = 0
+            server_sub.epoch = "_"
 
     async def _do_disconnect(self, code: int, reason: str, reconnect: bool) -> None:
         if self._ping_timer:

--- a/tests/test_state_invalidation.py
+++ b/tests/test_state_invalidation.py
@@ -1,6 +1,8 @@
 import asyncio
 import unittest
 
+import centrifuge.client as centrifuge_client
+import centrifuge.protocol.client_pb2 as protocol
 from centrifuge import Client
 from tests.fake_server import FakeCentrifugoServer
 
@@ -33,6 +35,22 @@ class TestInvalidateStateUnit(unittest.IsolatedAsyncioTestCase):
         # non-recoverable subscription it would stay False).
         self.assertTrue(sub._recover)
         self.assertIsNone(sub._prev_data)
+
+    async def test_invalidate_state_resets_server_sub_recovery_position(self):
+        client = Client("ws://localhost:0/connection/websocket")
+        client._server_subs["ch"] = centrifuge_client._ServerSubscription(
+            offset=10, epoch="e1", recoverable=True
+        )
+
+        client._invalidate_connection_state()
+
+        server_sub = client._server_subs["ch"]
+        self.assertEqual(server_sub.offset, 0)
+        # Recovery position reset to the sentinel epoch, mirroring client-side
+        # subscriptions, so the next connect can't recover from stale state.
+        self.assertEqual(server_sub.epoch, "_")
+        # The recoverable flag is left untouched.
+        self.assertTrue(server_sub.recoverable)
 
 
 class TestStateInvalidationWire(unittest.IsolatedAsyncioTestCase):
@@ -127,6 +145,78 @@ class TestStateInvalidationWire(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(last_connect.token, "conn-token-1")
         # Subscription was invalidated — resubscribe carries no token.
         self.assertEqual(self.server.last_subscribe().token, "")
+        await client.disconnect()
+
+    async def test_disconnect_3014_resets_server_sub_recovery_position(self):
+        # Server pushes a recoverable server-side subscription in the connect
+        # reply, the way Centrifugo does for subs configured server-side.
+        self.server.connect_result = protocol.ConnectResult(
+            client="fake-client",
+            version="0.0.0",
+            ping=25,
+            subs={"ch": protocol.SubscribeResult(recoverable=True, offset=5, epoch="e1")},
+        )
+
+        calls = []
+
+        async def get_token():
+            calls.append(1)
+            return "conn-token-1"
+
+        client = Client(
+            self.server.url,
+            use_protobuf=True,
+            token="conn-token-0",  # noqa: S106
+            get_token=get_token,
+            min_reconnect_delay=0.05,
+            max_reconnect_delay=0.2,
+        )
+
+        connected = asyncio.Future()
+
+        async def on_connected(ctx):
+            if not connected.done():
+                connected.set_result(ctx)
+
+        client.events.on_connected = on_connected
+        await client.connect()
+        await asyncio.wait_for(connected, timeout=5)
+
+        server_sub = client._server_subs["ch"]
+        # Offset arrives as "5" (a string), not 5: protobuf's default JSON
+        # mapping renders int64 fields as strings, and _process_server_subs()
+        # stores the decoded value as-is without casting to int.
+        self.assertEqual(server_sub.offset, "5")
+        self.assertEqual(server_sub.epoch, "e1")
+        self.assertTrue(server_sub.recoverable)
+
+        # Re-arm for the post-reconnect connected event.
+        reconnected = asyncio.Future()
+
+        async def on_reconnected(ctx):
+            if not reconnected.done():
+                reconnected.set_result(ctx)
+
+        client.events.on_connected = on_reconnected
+
+        # Server delivers "state invalidated" as a close frame (as Centrifugo does).
+        await self.server.disconnect_close(_STATE_INVALIDATED_DISCONNECT, "state invalidated")
+        await asyncio.wait_for(reconnected, timeout=5)
+
+        self.assertGreaterEqual(len(calls), 1, "get_token must be called after 3014")
+
+        # The reconnect's connect command must not request recovery from the
+        # stale pre-invalidation position: offset/epoch reset to the sentinel,
+        # while recover is still requested (recoverable left untouched).
+        connect_cmds = [cmd.connect for cmd in self.server.received if cmd.HasField("connect")]
+        self.assertGreaterEqual(len(connect_cmds), 2)
+        last_connect = connect_cmds[-1]
+        self.assertIn("ch", last_connect.subs)
+        sent_sub = last_connect.subs["ch"]
+        self.assertTrue(sent_sub.recover)
+        self.assertEqual(sent_sub.offset, 0)
+        self.assertEqual(sent_sub.epoch, "_")
+
         await client.disconnect()
 
 


### PR DESCRIPTION
## Summary

On disconnect code `3014` ("state invalidated"), `Client._invalidate_connection_state()` resets every **client-side** `Subscription`'s cached recovery position (offset/epoch) to the unrecoverable sentinel (offset `0`, epoch `"_"`) so the next resubscribe can't recover from now-invalid state. **Server-side** subscriptions (`self._server_subs`, populated from the Connect reply's `subs` field) were left untouched.

`_construct_connect_command()` unconditionally sends each server-side sub's cached `offset`/`epoch` as recovery params on every reconnect. So an application relying only on server-side subscriptions kept requesting recovery from the stale pre-invalidation position after a 3014 disconnect, defeating the entire point of state invalidation.

## Fix

In `_invalidate_connection_state()`, also reset `offset`/`epoch` to the sentinel for every entry in `self._server_subs`, leaving `recoverable` untouched — matching the existing behavior for client-side subscriptions.

This mirrors the same fix already applied in centrifugal/centrifuge-swift#135 and centrifugal/centrifuge-js#385.

## Test plan

- [x] Added a unit test (`test_invalidate_state_resets_server_sub_recovery_position`) asserting `_invalidate_connection_state()` resets a server sub's offset/epoch while leaving `recoverable` untouched.
- [x] Added a wire-level test (`test_disconnect_3014_resets_server_sub_recovery_position`) against the in-process fake server: a recoverable server-side sub with offset/epoch is established, a 3014 close is delivered, and the reconnect's `connect` command is asserted to carry the sentinel offset/epoch instead of the stale values. Both new tests fail without the fix and pass with it.
- [x] Full suite: `python -m unittest discover -s tests` (114 tests, against docker-compose Centrifugo) — all pass.
- [x] `ruff check .` and `ruff format --check .` — clean.