### PR TITLE
Cast server-side subscription offset to int in _process_server_subs

### DIFF
--- a/centrifuge/client.py
+++ b/centrifuge/client.py
@@ -707,7 +707,7 @@ class Client:
         logger.debug("process server subs: %s", subs)
         for channel, subscribe in subs.items():
             self._server_subs[channel] = _ServerSubscription(
-                offset=subscribe.get("offset", 0),
+                offset=int(subscribe.get("offset", 0)),
                 epoch=subscribe.get("epoch", ""),
                 recoverable=subscribe.get("recoverable", False),
             )

--- a/tests/test_state_invalidation.py
+++ b/tests/test_state_invalidation.py
@@ -183,10 +183,10 @@ class TestStateInvalidationWire(unittest.IsolatedAsyncioTestCase):
         await asyncio.wait_for(connected, timeout=5)
 
         server_sub = client._server_subs["ch"]
-        # Offset arrives as "5" (a string), not 5: protobuf's default JSON
-        # mapping renders int64 fields as strings, and _process_server_subs()
-        # stores the decoded value as-is without casting to int.
-        self.assertEqual(server_sub.offset, "5")
+        # Offset arrives as "5" (a string): protobuf's default JSON mapping
+        # renders int64 fields as strings. _process_server_subs() must cast it
+        # to int, matching the type of every other stored/emitted offset.
+        self.assertEqual(server_sub.offset, 5)
         self.assertEqual(server_sub.epoch, "e1")
         self.assertTrue(server_sub.recoverable)
 


### PR DESCRIPTION
## What changed

`Client._process_server_subs()` stored the connect reply's `offset` field as-is into `_ServerSubscription.offset` (a dataclass field typed `int`), instead of casting it with `int(...)` like every other offset value in the same code path does.

## Why

With the protobuf codec, `google.protobuf.json_format.MessageToDict` renders `int64` fields as JSON strings (the standard proto3 JSON mapping, done for JS interop). So for a server-side subscription delivered in the Connect reply, `_server_subs[channel].offset` ended up holding a `str` like `"5"` instead of `5` — until the first publication for that channel arrived and overwrote it with a real `int` via `_publication_from_proto()` (which does cast).

This is inconsistent with the rest of the same function, which two lines later builds `StreamPosition(offset=int(subscribe.get("offset", 0)), ...)` for the emitted `ServerSubscribedContext` — and with `_publication_from_proto`, which also casts. The stored offset is later sent back to the server as the `recover`/`offset` param on the next reconnect; protobuf's `ParseDict` happens to accept a numeric string for an int64 field, so this didn't break the wire behavior, but it left internal state with the wrong type until a publication came in to silently correct it.

## Verification

- `tests/test_state_invalidation.py` already had a test that connected via the protobuf codec with a recoverable server-side subscription and asserted `server_sub.offset == "5"` (a string), with a comment explicitly documenting this as `_process_server_subs()` storing the value "as-is without casting to int". That assertion described the bug. Updated it to assert `server_sub.offset == 5` (an int), matching the fix. It fails against the old code (`AssertionError: '5' != 5`) and passes with the fix.
- Ran the full suite: `make lint` (ruff, clean) and `make test` (114 tests, including the Docker-backed `tests/test_client.py` against a locally-started `docker compose` Centrifugo) — all pass.

No public API or behavior change: `_ServerSubscription` and `_process_server_subs` are private/internal.